### PR TITLE
Fix: use xref for IMDG links

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -7,7 +7,11 @@ content:
     branches: HEAD
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [master, v*]
+    branches: [master]
+    tags: [v*, "!v4.0*" , "!v3.12", "!v3.12.1", "!v3.12.2", "!v3.12.3",
+    "!v3.12.4", "!v3.12.5*", "!v3.12.6", "!v3.12.7", "!v3.12.8", "!v3.12.9",
+    "!v3.12.11", "!v3.11*", "!v3.10*", "!v3.9*", "!v3.8*", "!v3.7*", "!v3.6*",
+    "!v3.5*", "!v3.4*", "!v3.3*", "!v*-BETA*"]
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
     branches: [archive]

--- a/docs/modules/ROOT/pages/connecting-members.adoc
+++ b/docs/modules/ROOT/pages/connecting-members.adoc
@@ -18,12 +18,12 @@ You can think of Management Center as a client connecting to the Hazelcast IMDG 
 If you enabled TLS/SSL on a Hazelcast cluster, then you need to perform the 2.
 step listed above, i.e., upload a configuration file. This configuration file needs
 to contain the parameters same as the ones you provide in the case when a client
-connects to a TLS/SSL enabled Hazelcast cluster. See link:https://docs.hazelcast.org/docs/latest-dev/manual/html-single/#tlsssl[here^] for details on TLS/SSL configurations.
+connects to a TLS/SSL enabled Hazelcast cluster. See xref:imdg:security:tls-ssl.adoc[here] for details on TLS/SSL configurations.
 
 NOTE: When connecting to multiple clusters from the same Management Center, please ensure that the
 cluster names are unique.  Management Center does not support simultaneous connections to more than
 one cluster with the same cluster name.
 
 NOTE: If the cluster uses
-link:https://docs.hazelcast.org/docs/latest-dev/manual/html-single/#advanced-network-configuration[Advanced Network],
+xref:imdg:clusters:advanced-network-configuration.adoc[Advanced Network],
 then the provided member address should be the client address of the member.

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -108,7 +108,7 @@ image:ROOT:DashboardPage.png[Dashboard]
 
 See the xref:launching:launching.adoc[Launching the Management Center User Interface chapter] for more details.
 
-Also see link:https://docs.hazelcast.org/docs/latest-dev/manual/html-single/#starting-the-member-and-client[here^] and link:https://jet-start.sh/docs/get-started/installation[here^] for information on starting the IMDG and Jet clusters, respectively.
+Also see xref:imdg:starting-members-clients.adoc[here] and link:https://jet-start.sh/docs/get-started/installation[here^] for information on starting the IMDG and Jet clusters, respectively.
 
 You also have the **Dev Mode** option for development or evaluation purposes that provides
 quick access to Management Center without requiring any security credentials. See

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -108,7 +108,7 @@ image:ROOT:DashboardPage.png[Dashboard]
 
 See the xref:launching:launching.adoc[Launching the Management Center User Interface chapter] for more details.
 
-Also see xref:imdg:starting-members-clients.adoc[here] and link:https://jet-start.sh/docs/get-started/installation[here^] for information on starting the IMDG and Jet clusters, respectively.
+Also see xref:imdg:ROOT:starting-members-clients.adoc[here] and link:{jet-docs}docs/get-started/installation[here^] for information on starting the IMDG and Jet clusters, respectively.
 
 You also have the **Dev Mode** option for development or evaluation purposes that provides
 quick access to Management Center without requiring any security credentials. See

--- a/docs/modules/monitor-imdg/pages/cluster-administration.adoc
+++ b/docs/modules/monitor-imdg/pages/cluster-administration.adoc
@@ -66,7 +66,7 @@ cluster, this exception message is shown on the screen as a notification.
 The admin user can upgrade the cluster version once all members of
 the cluster have been upgraded to the intended
 codebase version as described in the Rolling Upgrade Procedure section
-of the http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#rolling-upgrade-procedure[Hazelcast IMDG Reference Manual].
+of the xref:imdg:installation:rolling-upgrades.adoc#rolling-upgrade-procedure[Hazelcast IMDG Reference Manual].
 
 Open the **Rolling Upgrade** tab to perform a Rolling Upgrade
 and change the cluster's version.
@@ -99,7 +99,7 @@ cannot recover from the failure since it cannot start or it fails to load
 its own data. In that case, you can force the cluster to clean its persisted
 data and make a fresh start. This process is called **force start**.
 
-NOTE: See the http://docs.hazelcast.org/docs/latest/manual/html-single/#force-start[Force Start section]
+NOTE: See the xref:imdg:storage:hot-restart-persistence.adoc#force-start[Force Start section]
 in the Hazelcast IMDG Reference Manual for more information on this operation.
 
 To perform a force start on the cluster, click on the **Force Start** button.
@@ -138,7 +138,7 @@ the maps and caches, then a partial start up to two missing members is
 safe against data loss. If there are more than two missing members or there
 are maps/caches with less than two backups, then data loss is expected.
 
-NOTE: See the http://docs.hazelcast.org/docs/latest-dev/manual/html-single/#partial-start[Partial Start section]
+NOTE: See the xref:imdg:storage:hot-restart-persistence.adoc#partial-start[Partial Start section]
 in the Hazelcast IMDG Reference Manual for more information on this
 operation and how to enable it.
 
@@ -173,14 +173,14 @@ already completed the data loading process. This field, i.e., "Remaining Data Lo
 shows how much time (in seconds) is left for Hazelcast to know at least one member
 has successfully restored its Hot Restart data and perform an automatic partial start.
 
-NOTE: See the http://docs.hazelcast.org/docs/latest/manual/html-single/#configuring-hot-restart[Configuring Hot Restart section]
+NOTE: See the xref:imdg:storage:hot-restart-persistence.adoc#configuring-hot-restart[Configuring Hot Restart section]
 in the Hazelcast IMDG Reference Manual for more information on the configuration elements `validation-timeout-seconds`
 and `data-load-timeout-seconds` mentioned above and how to configure them.
 
 NOTE: Force and partial start operations can also be performed using the REST
 API and the script `cluster.sh`. See the
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#using-rest-api-for-cluster-management[Using REST API for Cluster Management section]
-and http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#using-the-script-clustersh[Using the Script cluster.sh section]
+xref:imdg:management:cluster-utilities.adoc#using-rest-api-for-cluster-management[Using REST API for Cluster Management section]
+and xref:imdg:management:cluster-utilities.adoc#using-the-script-cluster-sh[Using the Script cluster.sh section]
 in the Hazelcast IMDG Reference Manual.
 
 === Hot Backup
@@ -194,7 +194,7 @@ to perform testing, quality assurance or reproduce an issue on the production da
 Note that you must first configure the Hot Backup directory programmatically
 (using the method `setBackupDir()`) or declaratively (using the element `backup-dir`)
 to be able to take a backup of the Hot Restart data. See the
-http://docs.hazelcast.org/docs/latest-dev/manual/html-single/#configuring-hot-backup[Configuring Hot Backup section]
+xref:imdg:storage:hot-restart-persistence.adoc#configuring-hot-backup[Configuring Hot Backup section]
 in the Hazelcast IMDG Reference Manual.
 
 If the backup directory is configured, you can start to perform the backup by

--- a/docs/modules/monitor-imdg/pages/dashboard.adoc
+++ b/docs/modules/monitor-imdg/pages/dashboard.adoc
@@ -76,7 +76,7 @@ image:ROOT:PartitionDistributionLegend.png[Partition Distribution per Member Leg
 You can see each member's partition percentages by placing the mouse cursor on the
 chart. In the above example, you can see that two members out of three share
 the total partition count (which is 271 by default and configurable; see the `hazelcast.partition.count`
-property explained in the xref:imdg:system-properties.adoc[System Properties appendix] of
+property explained in the xref:imdg:ROOT:system-properties.adoc[System Properties appendix] of
 the Hazelcast IMDG Reference Manual).
 
 NOTE: The partition distribution chart does not show any information

--- a/docs/modules/monitor-imdg/pages/dashboard.adoc
+++ b/docs/modules/monitor-imdg/pages/dashboard.adoc
@@ -76,8 +76,7 @@ image:ROOT:PartitionDistributionLegend.png[Partition Distribution per Member Leg
 You can see each member's partition percentages by placing the mouse cursor on the
 chart. In the above example, you can see that two members out of three share
 the total partition count (which is 271 by default and configurable; see the `hazelcast.partition.count`
-property explained in the
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#system-properties[System Properties appendix] of
+property explained in the xref:imdg:system-properties.adoc[System Properties appendix] of
 the Hazelcast IMDG Reference Manual).
 
 NOTE: The partition distribution chart does not show any information

--- a/docs/modules/monitor-imdg/pages/monitor-clients.adoc
+++ b/docs/modules/monitor-imdg/pages/monitor-clients.adoc
@@ -12,7 +12,7 @@ seeing the full information, you need to enable the client
 statistics before starting your clients. This can be done
 by setting the `hazelcast.client.statistics.enabled` system
 property to `true` on the *client*. Please see the
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#client-system-properties[Client System Properties section]
+xref:imdg:clients:java.adoc#client-system-properties[Client System Properties section]
 in the Hazelcast IMDG Reference Manual for more information.
 After you enable the client statistics, you can monitor your
 clients using the Management Center.
@@ -154,7 +154,7 @@ NOTE: Please note that you can configure the time interval for which
 the client statistics are collected and sent to the cluster,
 using the system property  `hazelcast.client.statistics.period.seconds`.
 See the
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#client-system-properties[System Properties section]
+xref:imdg:clients:java.adoc#client-system-properties[System Properties section]
 in the Hazelcast IMDG Reference Manual for more information.
 
 [[changing-cluster-client-filtering]]

--- a/docs/modules/monitor-imdg/pages/monitor-dds.adoc
+++ b/docs/modules/monitor-imdg/pages/monitor-dds.adoc
@@ -298,7 +298,7 @@ NOTE: You need to enable the statistics for caches to monitor them
 in the Management Center. Use the `<statistics-enabled>` element or
 `setStatisticsEnabled()` method in declarative or programmatic
 configuration, respectively, to enable the statistics. Please refer
-to the http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#jcache-declarative-configuration[JCache Declarative Configuration]
+to the xref:idmg:jcache:setup.adoc#jcache-declarative-configuration[JCache Declarative Configuration]
 section for more information.
 
 [[monitoring-replicated-maps]]

--- a/docs/modules/monitor-imdg/pages/monitor-dds.adoc
+++ b/docs/modules/monitor-imdg/pages/monitor-dds.adoc
@@ -298,7 +298,7 @@ NOTE: You need to enable the statistics for caches to monitor them
 in the Management Center. Use the `<statistics-enabled>` element or
 `setStatisticsEnabled()` method in declarative or programmatic
 configuration, respectively, to enable the statistics. Please refer
-to the xref:idmg:jcache:setup.adoc#jcache-declarative-configuration[JCache Declarative Configuration]
+to the xref:imdg:jcache:setup.adoc#jcache-declarative-configuration[JCache Declarative Configuration]
 section for more information.
 
 [[monitoring-replicated-maps]]
@@ -691,4 +691,3 @@ generated or used but the number of ID batches.
 The batch size is configurable, usually it contains hundreds
 or thousands of IDs.
 A client uses all IDs from a batch before a new batch is requested.
-

--- a/docs/modules/monitor-imdg/pages/monitor-wan-replication.adoc
+++ b/docs/modules/monitor-imdg/pages/monitor-wan-replication.adoc
@@ -92,7 +92,7 @@ for more information.
 . WAN synchronization using https://en.wikipedia.org/wiki/Merkle_tree[Merkle trees]: To
 initiate this type of synchronization, you need to configure the
 cluster members. See
-the http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#delta-wan-synchronization[Delta WAN Synchronization section]
+the xref:imdg:wan:advanced-features.adoc#delta-wan-synchronization[Delta WAN Synchronization section]
 in Hazelcast IMDG Reference Manual for details about configuring them. Make
 sure you meet synchronizing-wan-clusters#requirements-for-delta-wan-sync[all the requirements]
 to use Delta WAN Synchronization and do the configuration on both the source and target clusters.
@@ -155,7 +155,7 @@ be used for WAN sync.
 
 image:ROOT:AddWanReplicationConfiguration.png[Add Temporary WAN Replication Configuration]
 
-See the http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#wan-replication[WAN Replication section]
+See the xref:imdg:wan.adoc[WAN Replication section]
 in Hazelcast IMDG Reference Manual for details about the fields and their possible values.
 
 After clicking the **Add Configuration** button, the new WAN replication configuration

--- a/docs/modules/monitor-imdg/pages/monitor-wan-replication.adoc
+++ b/docs/modules/monitor-imdg/pages/monitor-wan-replication.adoc
@@ -155,7 +155,7 @@ be used for WAN sync.
 
 image:ROOT:AddWanReplicationConfiguration.png[Add Temporary WAN Replication Configuration]
 
-See the xref:imdg:wan.adoc[WAN Replication section]
+See the xref:imdg:wan:wan.adoc[WAN Replication section]
 in Hazelcast IMDG Reference Manual for details about the fields and their possible values.
 
 After clicking the **Add Configuration** button, the new WAN replication configuration

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "scripts": {
     "build-local": "cross-env DOCSEARCH_ENABLED=true GOOGLE_ANALYTICS_KEY=GTM-M267KFN antora --to-dir test --fetch --generator @antora/site-generator-default antora-playbook-local.yml",
-    "check-links-local": "antora --generator @antora/xref-validator antora-playbook-local.yml",
+    "check-links-local": "antora --fetch --generator @antora/xref-validator antora-playbook-local.yml",
     "serve": "serve test",
     "expose": "ngrok http 5000"
   },


### PR DESCRIPTION
Hi, I'm from MC team, a front-end developer.

While fixing broken IMDG docs links we discovered that some links in the docs are also broken (e.g. pointing to wrong sections).
This PR changes the remaining "raw" links to use cross-reference instead. 

Is there anything else that needs to be done?