### PR TITLE
Fix typos and remove references to .z branch

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -4,7 +4,7 @@ name: Build production site
 
 on:
   push:
-    branches: [ main, '*.z', archive ]
+    branches: [ main, archive ]
     tags: 
       - v*
 

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -4,7 +4,7 @@ name: Build staging site
 
 on:
   pull_request:
-    branches: [ main, '*.z', archive ]
+    branches: [ main, archive ]
 
 jobs:
   dispatch:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ name: Check for dead links
 
 on:
   pull_request:
-    branches: [main, '*.z', archive]
+    branches: [main, archive]
   workflow_dispatch:
 
 jobs:

--- a/README.adoc
+++ b/README.adoc
@@ -20,25 +20,21 @@ This section describes some important information about how this repository is s
 
 - The component name, version, and start page are configured in each branch's `antora.yml` file.
 - The navigation for all modules is stored in the ROOT module's `nav.adoc` file.
-- The {url-playbook}[docs site playbook] instructs Antora to automatically build the site using content in the `master` branch as well as any tags that are prefixed with *v*.
+- The {url-playbook}[docs site playbook] instructs Antora to automatically build the site using content in the `main` branch as well as any tags that are prefixed with *v*.
 
 == Release Workflow
 
-Documentation for new releases is hosted in versioned tags that are prefixed with `v`. For example, content for the `4.2020.12` version is hosted in the `v4.2020.12` tag. The `latest-dev` content is stored in the `master` branch
+Documentation for new releases is hosted in versioned tags that are prefixed with `v`. For example, content for the `4.2020.12` version is hosted in the `v4.2020.12` tag. The `latest-dev` content is stored in the `main` branch
 
-The documentation build process is triggered whenever you push a new tag to this repository or commit to the `master` branch.
+The documentation build process is triggered whenever you push a new tag to this repository or commit to the `main` branch.
 
 === Patch Releases
 
 This section guides you through the steps for releasing documentation for patch releases.
 
-. Find the `.z` branch for your version. For example, if you're working on content for version 4.2020.12, find the branch named `4.2020.z`.
+. When you are ready to release, create a new release branch from the `main` branch and name it with the full version number that you are releasing. For example, if you are releasing version 4.1.1, name the branch 4.2020.12.
 +
 TIP: For guidance on writing content, see the {url-contribute}[contribution guidelines].
-+
-NOTE: If a branch for your major or minor version does not exist, see <<major-and-minor-releases, Major and Minor Releases>>.
-
-. When you are ready to release, create a new release branch from the `.z` branch and name it with the full version number that you are releasing. For example, if you are releasing version 4.1.1, name the branch 4.2020.12.
 
 . In the `antora.yml` file of your release branch, update the `version` field with the version of Management Center that you are working on.
 +
@@ -49,13 +45,9 @@ version: 4.2020.12
 
 . Tag the latest commit in your release branch with a `v` followed by the version number.
 
-. If you have made any changes since creating your release branch, merge those changes back into the `.z` branch.
+. If you have made any changes since creating your release branch, merge those changes back into the `main` branch.
 
 . Delete your release branch.
-+
-WARNING: Do not delete the `.z` branch. This branch is for writing content for future patch releases.
-
-. In the `antora.yml` file of the `.z` branch, increment the `version` field. For example, `4.2021.02-SNAPSHOT` becomes `4.2021.03-SNAPSHOT`.
 
 . If you are releasing a new latest version, in the `develop` branch of the `hazelcast/hazelcast-docs` repository, submit a pull request to update the `_redirects` file with your release version of Management Center.
 +
@@ -73,11 +65,9 @@ The documentation site will now be built, including content from your tagged ver
 
 This section guides you through the steps for releasing documentation for major and minor releases.
 
-. Create a `\{version\}.z` branch from the `master` branch, where `\{version\}` is the version of Management Center that you are releasing. For example, if you're working on content for version 4.2021.02, create a branch named `4.2021.z`.
+. When you are ready to release, create a new release branch from the `main` branch and name it with the full version number that you are releasing. For example, if you are releasing version 4.2021.02, name the branch 4.2021.02.
 +
 TIP: For guidance on writing content, see the {url-contribute}[contribution guidelines].
-
-. When you are ready to release, create a new release branch from the `.z` branch and name it with the full version number that you are releasing. For example, if you are releasing version 4.2021.02, name the branch 4.2021.02.
 
 . In the `antora.yml` file of your release branch, update the `version` field with the version of Management Center that you are working on.
 +
@@ -88,15 +78,11 @@ version: 4.2021.02
 
 . Tag the latest commit in your release branch with a `v` followed by the version number.
 
-. If you have made any changes since creating your release branch, merge those changes back into the `.z` branch.
+. If you have made any changes since creating your release branch, merge those changes back into the `main` branch.
 
 . Delete your release branch.
-+
-WARNING: Do not delete the `.z` branch. This branch is for writing content for future patch releases.
 
-. In the `antora.yml` file of the `.z` branch, increment the `version` field. For example, `4.2021.02-SNAPSHOT` becomes `4.2021.03-SNAPSHOT`.
-
-. If you are releasing a new `latest-dev` version, in the `antora.yml` file of the `master` branch, increment the `version` field to the `latest-dev` version. For example, `4.2021.02-SNAPSHOT` becomes `4.2021.03-SNAPSHOT`.
+. If you are releasing a new `latest-dev` version, in the `antora.yml` file of the `main` branch, increment the `version` field to the `latest-dev` version. For example, `4.2021.02-SNAPSHOT` becomes `4.2021.03-SNAPSHOT`.
 
 . In the `develop` branch of the `hazelcast/hazelcast-docs` repository, submit a pull request to update the `_redirects` file with the new versions of Management Center.
 +
@@ -107,7 +93,7 @@ NOTE: This file is where we alias the `latest-dev` and `latest` paths in URLs.
 # Redirect latest management center alias to the latest version
 /management-center/latest/*  /management-center/4.2021.02/:splat 200!
 # Redirect latest-dev management center alias to the latest-dev version
-/management-center/latest-dev/*  /management-center/4.2021.02-SNAPSHOT/:splat 200!
+/management-center/latest-dev/*  /management-center/4.2021.03-SNAPSHOT/:splat 200!
 ----
 
 The documentation site will now be built, including content from your tagged version.
@@ -123,15 +109,15 @@ To automate some elements of the build process, this repository includes the fol
 
 |validate-site.yml
 |Validates that all internal and external links are working
-|On a pull request to the `master`, `archive`, and `*.z` branches
+|On a pull request to the `main`, `archive`, and `*.z` branches
 
 |build-staging.yml
 |Builds the staging documentation site by sending a build hook to Netlify (the hosting platform that we use)
-|On a pull request to the `master`, `archive`, and `*.z` branches
+|On a pull request to the `main`, `archive`, and `*.z` branches
 
 |build-site.yml
 |Builds the production documentation site by sending a build hook to Netlify (the hosting platform that we use)
-|On a push to the `master` branch and any tags whose names start with `v`
+|On a push to the `main` branch and any tags whose names start with `v`
 |===
 
 == Contributing


### PR DESCRIPTION
This project does not use `.z` branches because it does not support older versions.

Instead it branches from `main` for each release.