### PR TITLE
Add documentation for a new mc-conf command

### DIFF
--- a/src/docs/asciidoc/mc_conf_tool.adoc
+++ b/src/docs/asciidoc/mc_conf_tool.adoc
@@ -148,7 +148,7 @@ provide the path to the home directory with the `-H` (or `--home`) option.
 === Configuring Time Travel
 
 The `configure-time-travel` command enables or disables time travel for Management Center.
-When enabled, Management Center will persist metrics that it has received from the cluster
+When enabled, Management Center persists metrics that it has received from the cluster
 to the local disk.
 
 NOTE: If you have used a non-default Management Center home directory location, you must

--- a/src/docs/asciidoc/mc_conf_tool.adoc
+++ b/src/docs/asciidoc/mc_conf_tool.adoc
@@ -145,6 +145,15 @@ commands as the recovery mechanism.
 NOTE: If you have used a non-default Management Center home directory location, you must
 provide the path to the home directory with the `-H` (or `--home`) option.
 
+=== Configuring Time Travel
+
+The `configure-time-travel` command enables or disables time travel for Management Center.
+When enabled, Management Center will persist metrics that it has received from the cluster
+to the local disk.
+
+NOTE: If you have used a non-default Management Center home directory location, you must
+provide the path to the home directory with the `-H` (or `--home`) option.
+
 === Advanced Features
 
 MC-Conf supports interactive options for secure processing of passwords. Those options


### PR DESCRIPTION
We have a new mc-conf command named configure-time-travel, added in https://github.com/hazelcast/management-center/pull/4248.