### PR TITLE
renaming HZ_MC_ environment variables to be consistent with other env vars

### DIFF
--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -37,8 +37,8 @@ You have the following options to start the Management Center service:
 
 For all the starting options you can preconfigure a cluster in Management Center by setting the following environment variables:
 
-* `HZ_MC_MEMBERS` variable should contain a comma-separated list of the cluster member addresses.
-* `HZ_MC_CLUSTER` variable should contain the cluster name and defaults to `dev` if not provided.
+* `MC_DEFAULT_CLUSTER_MEMBERS` variable should contain a comma-separated list of the cluster member addresses.
+* `MC_DEFAULT_CLUSTER` variable should contain the cluster name and defaults to `dev` if not provided.
 
 [[starting-with-jar-file]]
 === Using the Command Line


### PR DESCRIPTION
Slack discussion: https://hazelcast.slack.com/archives/C0151J6CSDC/p1629895879072200

Code change: https://github.com/hazelcast/management-center/pull/4674