### PR TITLE
MC-895- remove 'CP sybsystem not supported' status

### DIFF
--- a/docs/modules/monitor-imdg/pages/cluster-administration.adoc
+++ b/docs/modules/monitor-imdg/pages/cluster-administration.adoc
@@ -124,7 +124,6 @@ image:ROOT:CPSubsystemTab.png[Status]
 The **Status** field shows a summary of the current CP subsystem status. It may have one of
 the following values:
 
-* **CP Subsystem is not supported by this cluster:** Shown for Hazelcast clusters with version prior to 3.12.
 * **CP Subsystem is not enabled:** Shown if CP subsystem is not enabled for the current cluster.
 * **All CP members are accessible:** Shown if there are at least the same amount of accessible CP members
 as the configured CP member count.


### PR DESCRIPTION
CP subsystem is supported by Hazelcast clusters 3.12+. Since MC5+ can't connect to pre 3.12 clusters we don't need NOT_SUPPORTED status anymore