### PR TITLE
Put version in single quotes

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,6 +1,6 @@
 name: management-center
 title: Management Center
-version: 5.0.1-SNAPSHOT
+version: '5.0.1-snapshot'
 prerelease: true
 asciidoc:
   attributes:


### PR DESCRIPTION
When the version includes a 0, Antora may strip it from the version unless the version is a string.