### PR TITLE
Add redirect

### DIFF
--- a/docs/modules/clusters/pages/client-filtering.adoc
+++ b/docs/modules/clusters/pages/client-filtering.adoc
@@ -1,5 +1,6 @@
 = Filtering Client Connections
 :description: Create filter lists that define which clients are allowed to connect to the cluster.
+:page-aliases: monitor-imdg:client-filtering.adoc
 :page-enterprise: true
 
 [[changing-cluster-client-filtering]]


### PR DESCRIPTION
We missed a redirect in #135. This PR redirects `/monitor-imdg/client-filtering` to the new location.