### PR TITLE
Migrate to hz-mc HZ-626

### DIFF
--- a/docs/modules/deploy-manage/pages/historical-metrics.adoc
+++ b/docs/modules/deploy-manage/pages/historical-metrics.adoc
@@ -76,7 +76,7 @@ this default directory by setting the `ROCKSDB_SHAREDLIB_DIR` environment variab
 ----
 mkdir $HOME/tmp/rocksdb
 export ROCKSDB_SHAREDLIB_DIR="$(realpath $HOME/tmp/rocksdb)"
-mc-start.sh
+hz-mc start
 ----
 
 === Slow Background Persistence Runs

--- a/docs/modules/deploy-manage/pages/local-security-provider.adoc
+++ b/docs/modules/deploy-manage/pages/local-security-provider.adoc
@@ -108,7 +108,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.security.dictionary.path=/usr/MCtext/pwd.txt \
+hz-mc start -Dhazelcast.mc.security.dictionary.path=/usr/MCtext/pwd.txt \
      -Dhazelcast.mc.security.dictionary.minWordLength=3
 ----
 --

--- a/docs/modules/deploy-manage/pages/serve-mc-over-https.adoc
+++ b/docs/modules/deploy-manage/pages/serve-mc-over-https.adoc
@@ -158,7 +158,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.enabled=true \
+hz-mc start -Dhazelcast.mc.tls.enabled=true \
 -Dhazelcast.mc.https.port=443 \ <1>
 -Dhazelcast.mc.tls.enableHttpPort=true \ <2>
 -Dhazelcast.mc.configReplacer.class=com.hazelcast.webmonitor.configreplacer.EncryptionReplacer \ <3>

--- a/docs/modules/deploy-manage/pages/serving-https.adoc
+++ b/docs/modules/deploy-manage/pages/serving-https.adoc
@@ -22,7 +22,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.enabled=true \
+hz-mc start -Dhazelcast.mc.tls.enabled=true \
      -Dhazelcast.mc.tls.keyStore=/path/to/keystore \
      -Dhazelcast.mc.tls.keyStorePassword=yourkeystorepassword
 ----
@@ -76,7 +76,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.enabled=true \
+hz-mc start -Dhazelcast.mc.tls.enabled=true \
      -Dhazelcast.mc.tls.keyStore=/path/to/keystore \
      -Dhazelcast.mc.tls.keyStorePassword=yourkeystorepassword \
      -Dhazelcast.mc.https.port=443

--- a/docs/modules/deploy-manage/pages/sessions.adoc
+++ b/docs/modules/deploy-manage/pages/sessions.adoc
@@ -25,7 +25,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.session.timeout.seconds=60
+hz-mc start -Dhazelcast.mc.session.timeout.seconds=60
 ----
 --
 Windows::

--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -10,7 +10,7 @@ If an environment variable isn't available for a property and you start Manageme
 +
 TIP: You may also need to use other environment variables. For the Docker reference, see link:https://hub.docker.com/r/hazelcast/management-center[DockerHub].
 - `mc-conf` tool
-- Start scripts included with Hazelcast Platform or Management Center such as `mc-start`.
+- Start scripts included with Hazelcast Platform or Management Center such as `hz-mc start`.
 
 You can use properties to configure both Management Center and Management Center's client connection strategy on startup.
 
@@ -30,7 +30,7 @@ ALLOW_MULTIPLE_LOGIN
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.allowMultipleLogin=true
+hz-mc start -Dhazelcast.mc.allowMultipleLogin=true
 ----
 
 |[[hazelcast-mc-auditlog-enabled]]hazelcast.mc.auditlog.enabled
@@ -40,7 +40,7 @@ AUDIT_LOG_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.auditlog.enabled=true \
+hz-mc start -Dhazelcast.mc.auditlog.enabled=true \
 -jar hazelcast-management-center-{full-version}.jar
 ----
 
@@ -49,7 +49,7 @@ mc-start.sh -Dhazelcast.mc.auditlog.enabled=true \
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.configReplacer.class=com.hazelcast.webmonitor.configreplacer.EncryptionReplacer \
+hz-mc start -Dhazelcast.mc.configReplacer.class=com.hazelcast.webmonitor.configreplacer.EncryptionReplacer \
 -jar hazelcast-management-center-{full-version}.jar
 ----
 
@@ -59,7 +59,7 @@ configuration loading process stops when a replacement value is missing. Default
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.configReplacer.failIfValueMissing=true \
+hz-mc start -Dhazelcast.mc.configReplacer.failIfValueMissing=true \
 -jar hazelcast-management-center-{full-version}.jar
 ----
 
@@ -70,7 +70,7 @@ CONTEXT_PATH
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.contextPath=hazelcast-mc \
+hz-mc start -Dhazelcast.mc.contextPath=hazelcast-mc \
 -jar hazelcast-management-center-{full-version}.jar
 ----
 
@@ -81,7 +81,7 @@ In this example, the URL for Management Center would be `\http:localhost:8080/ha
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.disableHostnameVerification=true
+hz-mc start -Dhazelcast.mc.disableHostnameVerification=true
 ----
 
 |[[hazelcast-mc-disableloginperiodmultiplier]]hazelcast.mc.disableLoginPeriodMultiplier
@@ -93,7 +93,7 @@ period expires. Default: `10`. See xref:sessions.adoc[].
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.disableLoginPeriodMultiplier=20
+hz-mc start -Dhazelcast.mc.disableLoginPeriodMultiplier=20
 ----
 
 |[[hazelcast-mc-exclude-cipher-suites]]hazelcast.mc.exclude.cipher.suites
@@ -103,7 +103,7 @@ EXCLUDE_CIPHER_SUITES
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.exclude.cipher.suites=^.*_(MD5\|SHA\|SHA1)$,^TLS_RSA_.*$,^.*_NULL_.*$
+hz-mc start -Dhazelcast.mc.exclude.cipher.suites=^.*_(MD5\|SHA\|SHA1)$,^TLS_RSA_.*$,^.*_NULL_.*$
 ----
 
 |[[hazelcast-mc-existingkeystore-path]]hazelcast.mc.existingKeyStore.path
@@ -114,7 +114,7 @@ Default: `' '` (empty).
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.existingKeyStore.path=/path/to/existing/keyStore.jceks
+hz-mc start -Dhazelcast.mc.existingKeyStore.path=/path/to/existing/keyStore.jceks
 ----
 
 |[[hazelcast-mc-existingkeystore-pass]]hazelcast.mc.existingKeyStore.pass
@@ -125,7 +125,7 @@ Default: `' '` (empty).
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.existingKeyStore.pass=somepass
+hz-mc start -Dhazelcast.mc.existingKeyStore.pass=somepass
 ----
 
 |[[hazelcast-mc-existingkeystore-type]]hazelcast.mc.existingKeyStore.type
@@ -136,7 +136,7 @@ Default: `JCEKS`.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.existingKeyStore.type=JCEKS
+hz-mc start -Dhazelcast.mc.existingKeyStore.type=JCEKS
 ----
 
 |[[hazelcast-mc-existingkeystore-provider]]hazelcast.mc.existingKeyStore.provider
@@ -147,7 +147,7 @@ Default: System provider.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.existingKeyStore.provider=com.yourprovider.MyProvider
+hz-mc start -Dhazelcast.mc.existingKeyStore.provider=com.yourprovider.MyProvider
 ----
 
 |[[hazelcast-mc-failedattemptsbeforedisablelogin]]hazelcast.mc.failedAttemptsBeforeDisableLogin
@@ -158,7 +158,7 @@ login attempts that Management Center allows before disabling logins. Default: `
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.failedAttemptsBeforeDisableLogin=1
+hz-mc start -Dhazelcast.mc.failedAttemptsBeforeDisableLogin=1
 ----
 
 |[[hazelcast-mc-forcelogoutonmultiplelogin]]hazelcast.mc.forceLogoutOnMultipleLogin
@@ -168,7 +168,7 @@ FORCE_LOGOUT_ON_MULTIPLE_LOGIN
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.forceLogoutOnMultipleLogin=true
+hz-mc start -Dhazelcast.mc.forceLogoutOnMultipleLogin=true
 ----
 
 |[[hazelcast-mc-forwarded-requests-enabled]]hazelcast.mc.forwarded.requests.enabled
@@ -179,7 +179,7 @@ headers from reverse proxies. Default: `true`.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.forwarded.requests.enabled=false
+hz-mc start -Dhazelcast.mc.forwarded.requests.enabled=false
 ----
 
 |[[enabling-health-check-endpoint]][[hazelcast-mc-healthcheck-enable]]hazelcast.mc.healthCheck.enable
@@ -190,7 +190,7 @@ status code if Management Center is running.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.healthCheck.enable=true
+hz-mc start -Dhazelcast.mc.healthCheck.enable=true
 ----
 
 In this example, the health check would be available at `\http://localhost:8081/health`.
@@ -202,7 +202,7 @@ HEALTH_CHECK_PORT
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.healthCheck.port=2000
+hz-mc start -Dhazelcast.mc.healthCheck.port=2000
 ----
 
 |[[hazelcast-mc-home]]hazelcast.mc.home
@@ -212,7 +212,7 @@ HOME_PROP
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.home=/home/management-center
+hz-mc start -Dhazelcast.mc.home=/home/management-center
 ----
 
 |[[hazelcast-mc-hostaddress]]hazelcast.mc.hostAddress
@@ -222,7 +222,7 @@ HOST_ADDRESS
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.hostAddress=127.0.1.1
+hz-mc start -Dhazelcast.mc.hostAddress=127.0.1.1
 ----
 
 |[[hazelcast-mc-http-port]]hazelcast.mc.http.port
@@ -244,7 +244,7 @@ INCLUDE_CIPHER_SUITES
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.include.cipher.suites=^SSL_.*$
+hz-mc start -Dhazelcast.mc.include.cipher.suites=^SSL_.*$
 ----
 
 |[[hazelcast-mc-initialdisableloginperiod]]hazelcast.mc.initialDisableLoginPeriod
@@ -255,7 +255,7 @@ login period in seconds. Default: `5`. See xref:sessions.adoc[].
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.initialDisableLoginPeriod=50
+hz-mc start -Dhazelcast.mc.initialDisableLoginPeriod=50
 ----
 
 |[[hazelcast-mc-jmx-enabled]]hazelcast.mc.jmx.enabled
@@ -265,7 +265,7 @@ JMX_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.enabled=true
+hz-mc start -Dhazelcast.mc.jmx.enabled=true
 ----
 
 |[[hazelcast-mc-jmx-host]]hazelcast.mc.jmx.host
@@ -275,7 +275,7 @@ JMX_HOST_NAME
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.host=127.0.0.1
+hz-mc start -Dhazelcast.mc.jmx.host=127.0.0.1
 ----
 
 |[[hazelcast-mc-jmx-mutualauthentication]]hazelcast.mc.jmx.mutualAuthentication
@@ -285,7 +285,7 @@ JMX_SSL_MUTUAL_AUTH_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.mutualAuthentication=false
+hz-mc start -Dhazelcast.mc.jmx.mutualAuthentication=false
 ----
 
 |[[hazelcast-mc-jmx-port]]hazelcast.mc.jmx.port
@@ -295,7 +295,7 @@ JMX_PORT
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.port=9000
+hz-mc start -Dhazelcast.mc.jmx.port=9000
 ----
 
 |[[hazelcast-mc-jmx-rmi-port]]hazelcast.mc.jmx.rmi.port
@@ -305,7 +305,7 @@ JMX_RMI_PORT
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.rmi.port=9001
+hz-mc start -Dhazelcast.mc.jmx.rmi.port=9001
 ----
 
 |[[hazelcast-mc-jmx-ssl]]hazelcast.mc.jmx.ssl
@@ -315,7 +315,7 @@ JMX_SSL_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl=true
+hz-mc start -Dhazelcast.mc.jmx.ssl=true
 ----
 
 |[[hazelcast-mc-jmx-ssl-keystore]]hazelcast.mc.jmx.ssl.keyStore
@@ -323,7 +323,7 @@ mc-start.sh -Dhazelcast.mc.jmx.ssl=true
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl.keyStore=/some/dir/selfsigned.jks
+hz-mc start -Dhazelcast.mc.jmx.ssl.keyStore=/some/dir/selfsigned.jks
 ----
 
 |[[hazelcast-mc-jmx-ssl-keystorepassword]]hazelcast.mc.jmx.ssl.keyStorePassword
@@ -331,7 +331,7 @@ mc-start.sh -Dhazelcast.mc.jmx.ssl.keyStore=/some/dir/selfsigned.jks
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl.keyStorePassword=myPassword
+hz-mc start -Dhazelcast.mc.jmx.ssl.keyStorePassword=myPassword
 ----
 
 |[[hazelcast-mc-jmx-ssl-truststore]]hazelcast.mc.jmx.ssl.trustStore
@@ -339,7 +339,7 @@ mc-start.sh -Dhazelcast.mc.jmx.ssl.keyStorePassword=myPassword
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl.trustStore=/some/dir/truststore
+hz-mc start -Dhazelcast.mc.jmx.ssl.trustStore=/some/dir/truststore
 ----
 
 |[[hazelcast-mc-jmx-ssl-truststorepassword]]hazelcast.mc.jmx.ssl.trustStorePassword
@@ -347,7 +347,7 @@ mc-start.sh -Dhazelcast.mc.jmx.ssl.trustStore=/some/dir/truststore
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl.trustStorePassword=myPassword
+hz-mc start -Dhazelcast.mc.jmx.ssl.trustStorePassword=myPassword
 ----
 
 |[[hazelcast-mc-jmx-ssl-keystoretype]]hazelcast.mc.jmx.ssl.keyStoreType
@@ -355,7 +355,7 @@ mc-start.sh -Dhazelcast.mc.jmx.ssl.trustStorePassword=myPassword
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl.keyStoreType=JKS
+hz-mc start -Dhazelcast.mc.jmx.ssl.keyStoreType=JKS
 ----
 
 |[[hazelcast-mc-jmx-ssl-keymanageralgorithm]]hazelcast.mc.jmx.ssl.keyManagerAlgorithm
@@ -367,7 +367,7 @@ the `javax.net.ssl.KeyManagerFactory#getDefaultAlgorithm` method. Default: Syste
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.ssl.keyManagerAlgorithm=JKS
+hz-mc start -Dhazelcast.mc.jmx.ssl.keyManagerAlgorithm=JKS
 ----
 
 |[[hazelcast-mc-ldap-timeout]]hazelcast.mc.ldap.timeout
@@ -377,7 +377,7 @@ LDAP_CONN_TIMEOUT_MILLIS
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.ldap.timeout=4000 \
+hz-mc start -Dhazelcast.mc.ldap.timeout=4000 \
     
 ----
 
@@ -389,7 +389,7 @@ over one that is set in the user interface, and you cannot update the license in
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.license={license key}
+hz-mc start -Dhazelcast.mc.license={license key}
 ----
 
 |[[hazelcast-mc-lock-skip]]hazelcast.mc.lock.skip
@@ -399,7 +399,7 @@ SKIP_MC_LOCK_CHECK
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.lock.skip=true
+hz-mc start -Dhazelcast.mc.lock.skip=true
 ----
 
 |[[hazelcast-mc-maxdisableloginperiod]]hazelcast.mc.maxDisableLoginPeriod
@@ -411,7 +411,7 @@ disabled login period is unlimited.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.maxDisableLoginPeriod= \
+hz-mc start -Dhazelcast.mc.maxDisableLoginPeriod= \
     
 ----
 
@@ -422,7 +422,7 @@ PERSISTENT_STORE_TTL_DURATION
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.metrics.disk.ttl.duration=P2D
+hz-mc start -Dhazelcast.mc.metrics.disk.ttl.duration=P2D
 ----
 
 |[[hazelcast-mc-periodic-healthcheck-enabled]]hazelcast.mc.periodic.healthcheck.enabled
@@ -432,7 +432,7 @@ PERIODIC_HEALTHCHECK_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.periodic.healthcheck.enabled=true
+hz-mc start -Dhazelcast.mc.periodic.healthcheck.enabled=true
 ----
 
 |[[hazelcast-mc-phone-home-enabled]]hazelcast.mc.phone.home.enabled
@@ -442,7 +442,7 @@ PHONE_HOME_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.phone.home.enabled=false \
+hz-mc start -Dhazelcast.mc.phone.home.enabled=false \
     
 ----
 
@@ -453,7 +453,7 @@ PROMETHEUS_EXPORTER_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.enabled=true \
+hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
     
 ----
 
@@ -464,7 +464,7 @@ PROMETHEUS_EXPORTER_ALLOWLIST
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.filter.metrics.included=hz_topic_totalReceivedMessages,hz_map_totalPutLatency \
+hz-mc start -Dhazelcast.mc.prometheusExporter.filter.metrics.included=hz_topic_totalReceivedMessages,hz_map_totalPutLatency \
     
 ----
 
@@ -475,7 +475,7 @@ PROMETHEUS_EXPORTER_DENYLIST
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.filter.metrics.excluded=hz_os_systemLoadAverage,hz_memory_freeHeap \
+hz-mc start -Dhazelcast.mc.prometheusExporter.filter.metrics.excluded=hz_os_systemLoadAverage,hz_memory_freeHeap \
     
 ----
 
@@ -491,7 +491,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.enabled=true \
+hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
   -Dhazelcast.mc.prometheusExporter.port=2222
 ----
 --
@@ -515,7 +515,7 @@ PASSWORD_DICTIONARY_MIN_WORD_LENGTH
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.security.dictionary.path=/usr/MCtext/pwd.txt \
+hz-mc start -Dhazelcast.mc.security.dictionary.path=/usr/MCtext/pwd.txt \
      -Dhazelcast.mc.security.dictionary.minWordLength=3 \
     
 ----
@@ -527,7 +527,7 @@ PASSWORD_DICTIONARY_PATH
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.security.dictionary.path=/usr/MCtext/pwd.txt \
+hz-mc start -Dhazelcast.mc.security.dictionary.path=/usr/MCtext/pwd.txt \
     
 ----
 
@@ -538,7 +538,7 @@ SESSION_TIMEOUT_SECONDS
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.session.timeout.seconds=60
+hz-mc start -Dhazelcast.mc.session.timeout.seconds=60
 ----
 
 |[[metadata-polling-config]][[hazelcast-mc-state-reschedule-delay-millis]]hazelcast.mc.state.reschedule.delay.millis
@@ -549,7 +549,7 @@ list of all data structures and their configurations. Default: 1000.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.state.reschedule.delay.millis=2000
+hz-mc start -Dhazelcast.mc.state.reschedule.delay.millis=2000
 ----
 
 |[[hazelcast-mc-tls-excludeprotocols]]hazelcast.mc.tls.excludeProtocols
@@ -559,7 +559,7 @@ TLS_EXCLUDE_PROTOCOLS
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.excludeProtocols=SSLv3
+hz-mc start -Dhazelcast.mc.tls.excludeProtocols=SSLv3
 ----
 
 |[[hazelcast-mc-tls-openssl]]hazelcast.mc.tls.openSsl
@@ -569,7 +569,7 @@ TLS_OPEN_SSL
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.openSsl=true
+hz-mc start -Dhazelcast.mc.tls.openSsl=true
 ----
 
 |[[hazelcast-mc-tls-enabled]]hazelcast.mc.tls.enabled
@@ -579,7 +579,7 @@ TLS_ENABLED
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.enabled=true
+hz-mc start -Dhazelcast.mc.tls.enabled=true
 ----
 
 |[[hazelcast-mc-tls-keystore]]hazelcast.mc.tls.keyStore
@@ -589,7 +589,7 @@ TLS_KEYSTORE_PATH
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.keyStore=/keys/mc.keystore
+hz-mc start -Dhazelcast.mc.tls.keyStore=/keys/mc.keystore
 ----
 
 |[[hazelcast-mc-tls-keystorepassword]]hazelcast.mc.tls.keyStorePassword
@@ -599,7 +599,7 @@ TLS_KEYSTORE_PASS
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.keyStorePassword=mypassword123
+hz-mc start -Dhazelcast.mc.tls.keyStorePassword=mypassword123
 ----
 
 |[[hazelcast-mc-tls-truststore]]hazelcast.mc.tls.trustStore
@@ -609,7 +609,7 @@ TLS_TRUSTSTORE_PATH
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.trustStore=/truststores/mc.truststore
+hz-mc start -Dhazelcast.mc.tls.trustStore=/truststores/mc.truststore
 ----
 
 |[[hazelcast-mc-tls-truststorepassword]]hazelcast.mc.tls.trustStorePassword
@@ -619,7 +619,7 @@ TLS_TRUSTSTORE_PASS
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.trustStorePassword=mypassword123
+hz-mc start -Dhazelcast.mc.tls.trustStorePassword=mypassword123
 ----
 
 |[[hazelcast.mc.tls.enableHttpPort]]hazelcast.mc.tls.enableHttpPort
@@ -629,7 +629,7 @@ TLS_ENABLE_HTTP_PORT
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.trustStorePassword=mypassword123
+hz-mc start -Dhazelcast.mc.tls.trustStorePassword=mypassword123
 ----
 
 |[[hazelcast-mc-tls-mutualauthentication]]hazelcast.mc.tls.mutualAuthentication
@@ -644,7 +644,7 @@ Default: `OPTIONAL`.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.mutualAuthentication=REQUIRED
+hz-mc start -Dhazelcast.mc.tls.mutualAuthentication=REQUIRED
 ----
 
 |[[hazelcast-mc-useexistingkeystore]]hazelcast.mc.useExistingKeyStore
@@ -655,7 +655,7 @@ Default: `false`.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.useExistingKeyStore=true
+hz-mc start -Dhazelcast.mc.useExistingKeyStore=true
 ----
 
 |===
@@ -679,7 +679,7 @@ Values must be between 30000 and 600000.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.client.max.backoff.millis=486000
+hz-mc start -Dhazelcast.mc.client.max.backoff.millis=486000
 ----
 
 |[[hazelcast-mc-client-backoff-multiplier]]hazelcast.mc.client.backoff.multiplier
@@ -688,7 +688,7 @@ each failed retry. Default: `2`. Values must be between 1 and 10.
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.client.backoff.multiplier=3
+hz-mc start -Dhazelcast.mc.client.backoff.multiplier=3
 ----
 
 |[[hazelcast-mc-client-initial-backoff-millis]]hazelcast.mc.client.initial.backoff.millis
@@ -696,7 +696,7 @@ mc-start.sh -Dhazelcast.mc.client.backoff.multiplier=3
 |
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.client.initial.backoff.millis=2000
+hz-mc start -Dhazelcast.mc.client.initial.backoff.millis=2000
 ----
 
 |===

--- a/docs/modules/deploy-manage/pages/variable-replacers.adoc
+++ b/docs/modules/deploy-manage/pages/variable-replacers.adoc
@@ -57,7 +57,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.tls.enabled=true \
+hz-mc start -Dhazelcast.mc.tls.enabled=true \
     -Dhazelcast.mc.configReplacer.class=com.hazelcast.webmonitor.configreplacer.EncryptionReplacer \ <1>
     -Dhazelcast.mc.configReplacer.prop.passwordFile=path/to/password \
     -Dhazelcast.mc.configReplacer.prop.passwordUserProperties=false \

--- a/docs/modules/getting-started/pages/install.adoc
+++ b/docs/modules/getting-started/pages/install.adoc
@@ -78,7 +78,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh 
+hz-mc start
 ----
 --
 Windows::
@@ -102,7 +102,7 @@ Linux and Mac::
 [source,bash,subs="attributes+"]
 ----
 export MC_CLASSPATH="/path/to/an/extra.jar:/path/to/an/otherextra.jar"
-mc-start.sh 
+hz-mc start
 ----
 --
 

--- a/docs/modules/integrate/pages/jmx.adoc
+++ b/docs/modules/integrate/pages/jmx.adoc
@@ -16,7 +16,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.enabled=true \
+hz-mc start -Dhazelcast.mc.jmx.enabled=true \
 -Dcom.sun.management.jmxremote.ssl=false <1>
 ----
 --
@@ -66,7 +66,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.enabled=true \
+hz-mc start -Dhazelcast.mc.jmx.enabled=true \
     -Dhazelcast.mc.jmx.port=65432 \
     -Dhazelcast.mc.jmx.ssl=true \
     -Dhazelcast.mc.jmx.ssl.keyStore=/some/dir/selfsigned.jks \
@@ -119,7 +119,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.jmx.enabled=true \
+hz-mc start -Dhazelcast.mc.jmx.enabled=true \
     -Dhazelcast.mc.jmx.port=65432 \
     -Dhazelcast.mc.jmx.ssl=true \
     -Dhazelcast.mc.jmx.mutualAuthentication=true \

--- a/docs/modules/integrate/pages/prometheus-monitoring.adoc
+++ b/docs/modules/integrate/pages/prometheus-monitoring.adoc
@@ -109,7 +109,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.enabled=true \
+hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
   -Dhazelcast.mc.prometheusExporter.filter.metrics.included=hz_topic_totalReceivedMessages,hz_map_totalPutLatency
 ----
 --
@@ -135,7 +135,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.enabled=true \
+hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
   -Dhazelcast.mc.prometheusExporter.filter.metrics.excluded=hz_os_systemLoadAverage,hz_memory_freeHeap
 ----
 --
@@ -162,7 +162,7 @@ Linux and Mac::
 --
 [source,bash,subs="attributes+"]
 ----
-mc-start.sh -Dhazelcast.mc.prometheusExporter.enabled=true \
+hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
   -Dhazelcast.mc.prometheusExporter.port=2222
 ----
 --


### PR DESCRIPTION
We’ve decided to replace `mc-start.sh` with a new `hz-mc` command (excluding Windows scripts), see: https://github.com/hazelcast/management-center/pull/5186

Related to:
- https://hazelcast.atlassian.net/browse/HZ-626
