### PR TITLE
MC-1775 - update custom logging config property

### DIFF
--- a/docs/modules/deploy-manage/pages/logging.adoc
+++ b/docs/modules/deploy-manage/pages/logging.adoc
@@ -73,12 +73,12 @@ Management Center with the `hazelcast.mc.log.level` property. For example, to us
 
 To further customize the logging configuration, you can create a custom
 Log4j configuration file and start Management Center with
-the `log4j.configurationFile` property.
+the `logging.config` property.
 
 For example, you can create a file named `log4j2-custom.properties` with the following
 content and set logging level to `DEBUG`.
 To use this file as the logging configuration, you would start Management Center with the
-`-Dlog4j.configurationFile=/path/to/your/log4j2-custom.properties` command line parameter:
+`-Dlogging.config=/path/to/your/log4j2-custom.properties` command line parameter:
 
 [source,properties]
 ----


### PR DESCRIPTION
Spring Boot property for custom logging is `logging.config`.
`log4j.configurationFile` partially works, the log files are created, but they are empty and stdout config is not overridden.