### PR TITLE
MC-1671 Incorrect information on map browser -[docs]

### DIFF
--- a/docs/modules/data-structures/pages/map.adoc
+++ b/docs/modules/data-structures/pages/map.adoc
@@ -82,6 +82,8 @@ listed.
 
 |===
 
+NOTE: To get all these fields, the map must have its `per-entry-stats-enabled` element set to `true`. See the xref:hazelcast:data-structures:reading-map-metrics.adoc#getting-statistics-about-a-specific-map-entry[Reading Map Metrics] section.
+
 If you are using a serialization mechanism other than standard Java
 serialization for storing values in your map, you need to
 configure the client that Management Center uses for connecting to the


### PR DESCRIPTION
- Some map browser fields didn't get as expected in MC.
- It is because the map's `per-entry-stats` config is disabled by default.
- Added a warning to the MC to state that cause and added a link to the MC docs.
- Added an explanation in MC docs and link to the Hazelcast docs. 