### PR TITLE
MC-2127 Prometheus metrics - make timestamp optional

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -15,7 +15,7 @@ content:
     start_path: docs
   - url: https://github.com/hazelcast/management-center
     branches: [master]
-    start_path: src/openapi/external
+    start_path: hazelcast-management-center/src/openapi/external
 ui: 
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip

--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -728,7 +728,7 @@ hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
 
 ----
 
-|[[hazelcast-mc-prometheusexporter-timestamp-enabled]]hazelcast.mc.prometheusExporter.timestamp.enabled
+|[[prometheus-timestamp]]hazelcast.mc.prometheusExporter.timestamp.enabled
 
 MC_PROMETHEUS_EXPORTER_TIMESTAMP_ENABLED
 |Whether to send timestamp of the individual members' metrics to Prometheus. Its default value is `true` (enabled).

--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -731,7 +731,7 @@ hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
 |[[hazelcast-mc-prometheusexporter-timestamp-enabled]]hazelcast.mc.prometheusExporter.timestamp.enabled
 
 MC_PROMETHEUS_EXPORTER_TIMESTAMP_ENABLED
-|Whether to send timestamp of the individual members' metrics to Prometheus. Default `true`.
+|Whether to send timestamp of the individual members' metrics to Prometheus. Its default value is `true` (enabled).
 |
 [source,bash,subs="attributes+"]
 ----

--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -728,6 +728,17 @@ hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
 
 ----
 
+|[[hazelcast-mc-prometheusexporter-timestamp-enabled]]hazelcast.mc.prometheusExporter.timestamp.enabled
+
+MC_PROMETHEUS_EXPORTER_TIMESTAMP_ENABLED
+|Whether to send timestamp of the individual members' metrics to Prometheus. Default `true`.
+|
+[source,bash,subs="attributes+"]
+----
+hz-mc start -Dhazelcast.mc.prometheusExporter.timestamp.enabled=false \
+
+----
+
 |[[hazelcast-mc-prometheusExporter-filter-metrics-included]]hazelcast.mc.prometheusExporter.filter.metrics.included
 
 MC_PROMETHEUS_EXPORTER_FILTER_METRICS_INCLUDED

--- a/docs/modules/integrate/pages/prometheus-monitoring.adoc
+++ b/docs/modules/integrate/pages/prometheus-monitoring.adoc
@@ -13,6 +13,12 @@ Metrics are exposed to the `/metrics` endpoint, which is the default Prometheus 
 
 NOTE: All metrics are exported with the `hz_` prefix.
 
+== Disabling Timestamp
+
+Management Center collects metrics with the timestamp of the individual members and send this timestamp to Prometheus each time. Prometheus discards metrics with old timestamps. You can disable sending timestamp to Prometheus so that your monitoring system continues to operate when clock shifts happen in the cluster.
+
+To disable sending timestamp to Prometheus, set the `hazelcast.mc.prometheusExporter.timestamp.enabled` system property to `false`.
+
 == Configuring Prometheus
 
 After enabling the Prometheus exporter, you can configure your Prometheus YAML file to scrape metrics from Management Center.

--- a/docs/modules/integrate/pages/prometheus-monitoring.adoc
+++ b/docs/modules/integrate/pages/prometheus-monitoring.adoc
@@ -15,7 +15,7 @@ NOTE: All metrics are exported with the `hz_` prefix.
 
 == Disabling Timestamp
 
-Management Center collects metrics with the timestamp of the individual members and send this timestamp to Prometheus each time. Prometheus discards metrics with old timestamps. You can disable sending timestamp to Prometheus so that your monitoring system continues to operate when clock shifts happen in the cluster.
+Management Center collects metrics with the timestamp of individual members, and sends this timestamp to Prometheus each time. Prometheus discards metrics with the old timestamps. You can disable sending the timestamp to Prometheus so that your monitoring system continues to operate when clock shifts happen in the cluster.
 
 To disable sending timestamp to Prometheus, set the `hazelcast.mc.prometheusExporter.timestamp.enabled` system property to `false`.
 

--- a/docs/modules/integrate/pages/prometheus-monitoring.adoc
+++ b/docs/modules/integrate/pages/prometheus-monitoring.adoc
@@ -17,7 +17,7 @@ NOTE: All metrics are exported with the `hz_` prefix.
 
 Management Center collects metrics with the timestamp of individual members, and sends this timestamp to Prometheus each time. Prometheus discards metrics with the old timestamps. You can disable sending the timestamp to Prometheus so that your monitoring system continues to operate when clock shifts happen in the cluster.
 
-To disable sending timestamp to Prometheus, set the `hazelcast.mc.prometheusExporter.timestamp.enabled` system property to `false`.
+To disable sending timestamp to Prometheus, set the <<prometheus-timestamp, `hazelcast.mc.prometheusExporter.timestamp.enabled`>> property to `false`.
 
 == Configuring Prometheus
 


### PR DESCRIPTION
- Management Center collects metrics with the timestamp of the individual members and send this timestamp to Prometheus each time. 
- Prometheus discards metrics with old timestamps. 
- We need to disable sending this timestamp to Prometheus so that user's monitoring system continues to operate when clock shifts happen in the cluster.