### PR TITLE
Ensure `README`'s `Contributing` section links to the right repository

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -186,7 +186,7 @@ To automate some elements of the build process, this repository includes the fol
 
 If you want to add a change or contribute new content, see our {url-contribute}[contributing guide].
 
-To let us know about something that you'd like us to change, consider {url-org}/hazelcast-reference-manual/issues/new[creating an issue].
+To let us know about something that you'd like us to change, consider {url-org}/management-center-docs/issues/new[creating an issue].
 
 == License
 


### PR DESCRIPTION
Currently links to a [deprecated repository](https://github.com/hazelcast/hazelcast-reference-manual?tab=readme-ov-file#deprecated-this-repository-has-been-deprecated-please-continue-to-httpsgithubcomhazelcastimdg-docs), when should link to this repository.