### PR TITLE
MC `5.5` does not list compatibility with HZ `5.5`

### DIFF
--- a/docs/modules/getting-started/pages/overview.adoc
+++ b/docs/modules/getting-started/pages/overview.adoc
@@ -56,6 +56,8 @@ Management Center supports the following versions of Hazelcast:
 
 |Hazelcast Platform
 |
+5.5.x
+
 5.4.x
 
 5.3.x


### PR DESCRIPTION
I believe the latest released versions of Hazelcast and Management Center are compatible.