### PR TITLE
Revert `page-latest-supported-hazelcast` to `6.0-snapshot` [DOC-125]

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast:'6.0-snapshot'
+    page-latest-supported-hazelcast: '6.0-snapshot'
     page-toclevels: 1
     experimental: true
 nav:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast: '5.5.0'
+    page-latest-supported-hazelcast:'6.0-snapshot'
     page-toclevels: 1
     experimental: true
 nav:


### PR DESCRIPTION
[The dead links checks in `hz-docs` are failing](https://github.com/hazelcast/hz-docs/actions/workflows/validate.yml).

_One_ of the reasons for this is that the action checks out the default branch for all repos, builds the documentation and checks for linkage errors.

The problem is that `hz-docs` is building `6.0-snapshot` docs, but the `management-center-docs` links are to `5.5.0`, which doesn't exist locally in this configuration.

I believe this is why when `hz-docs`'s version was upgraded, so was [`management-center-docs`, too](https://github.com/hazelcast/management-center-docs/commit/36aa40a611cae82a2442dfc2c48fdcecb4401807).

This was subsequently reverted in https://github.com/hazelcast/management-center-docs/pull/355, which _I don't believe_ was intentional.

_Partially fixes_: [DOC-125](https://hazelcast.atlassian.net/browse/DOC-125)

[DOC-125]: https://hazelcast.atlassian.net/browse/DOC-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ