### PR TITLE
Fix latest supported platform version

### DIFF
--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -8,7 +8,7 @@ site:
     docsearch_api: 'ef7bd9485eafbd75d6e8425949eda1f5'
     docsearch_index: 'prod_hazelcast_docs'
 content:
-  sources: 
+  sources:
   - url: .
     branches: HEAD
     start_path: docs
@@ -16,7 +16,7 @@ content:
     branches: [main]
     start_paths: [home,tutorials]
   - url: https://github.com/hazelcast/hz-docs
-    branches: [main]
+    branches: [main, v/*]
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
     branches: [main]
@@ -151,9 +151,9 @@ content:
     start_path: docs
   - url: https://github.com/hazelcast/clc-docs
     branches: main
-    start_path: docs    
+    start_path: docs
 
-ui: 
+ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.2/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -10,7 +10,7 @@ site:
 content:
   sources:
   - url: .
-    branches: [HEAD, v/5.5]
+    branches: [main, v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
     branches: [main]

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -10,7 +10,10 @@ site:
 content:
   sources:
   - url: .
-    branches: [main, v/5.5]
+    branches: HEAD
+    start_path: docs
+  - url: https://github.com/hazelcast/management-center-docs
+    branches: [v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
     branches: [main]

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -10,7 +10,7 @@ site:
 content:
   sources:
   - url: .
-    branches: HEAD
+    branches: [HEAD, v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
     branches: [main]

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -10,7 +10,7 @@ site:
 content:
   sources:
   - url: .
-    branches: HEAD
+    branches: [main, v/*]
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
     branches: [main]

--- a/check-links-playbook.yml
+++ b/check-links-playbook.yml
@@ -10,13 +10,13 @@ site:
 content:
   sources:
   - url: .
-    branches: [main, v/*]
+    branches: HEAD
     start_path: docs
   - url: https://github.com/hazelcast/hazelcast-docs
     branches: [main]
     start_paths: [home,tutorials]
   - url: https://github.com/hazelcast/hz-docs
-    branches: [main, v/*]
+    branches: [main, v/5.5]
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
     branches: [main]

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast: '5.5.0'
+    page-latest-supported-hazelcast: '5.5'
     page-toclevels: 1
     experimental: true
 nav:


### PR DESCRIPTION
There is no 5.5.0 branch in hz-docs repo. The correct branch name is 5.5
Probably it is causing a bunch of errors during build 
![image](https://github.com/user-attachments/assets/58f95df7-d7b0-4515-bed6-963caa288be1)

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66d57f135ffe120008c408d8#L637