### PR TITLE
Add `page-latest-supported-clc`

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,9 @@ asciidoc:
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast: '6.0-snapshot'
+    page-latest-supported-hazelcast: '6.0-snapshot'    
+    # https://github.com/hazelcast/clc/releases
+    page-latest-supported-clc: '5.4.1'
     page-toclevels: 1
     experimental: true
 nav:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast: '6.0-snapshot'    
+    page-latest-supported-hazelcast: '6.0-snapshot'
     # https://github.com/hazelcast/clc/releases
     page-latest-supported-clc: '5.4.1'
     page-toclevels: 1


### PR DESCRIPTION
Required to support updating [`latest-supported-mc` in `clc-docs`](https://github.com/hazelcast/clc-docs/blob/e2c20ca40fc13d38f09b6bba761a9fcacd2bfe2d/docs/antora.yml#L20), in https://github.com/hazelcast/management-center/pull/9786

Post-merge action:
- [ ] Update [CLC release documentation](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/3731193857/Commandline+Client+Releases) to add this manual step (it's already manual in `hz-docs`)