### PR TITLE
Fix build warnings v/4.2021.03

### DIFF
--- a/docs/modules/launching/pages/auth-options.adoc
+++ b/docs/modules/launching/pages/auth-options.adoc
@@ -52,10 +52,10 @@ Provide the details in this form for your Active Directory server:
 schema (`ldap://` or `ldaps://`) and port.
 * **Domain:** Domain of your organization on Active Directory.
 * **User Search Filter:** LDAP search filter expression to search
-for the users. `{0}` will be replaced with `username@domain` and
-`{1}` will be replaced with only the `username`. You can use both
+for the users. `\{0}` will be replaced with `username@domain` and
+`\{1}` will be replaced with only the `username`. You can use both
 placeholders, only one of them or none in your search filter. For
-example, `(&(objectClass=user)(userPrincipalName={0}))` searches
+example, `(&(objectClass=user)(userPrincipalName=\{0}))` searches
 for a username that matches with the `userPrincipalName` attribute
 and member of the object class `user`.
 * **Admin Group(s):** Members of this group and its nested groups
@@ -258,10 +258,10 @@ have the privilege to see only the metrics on the Management Center.
 To use more than one group, separate them with a semicolon (;).
 * **Start TLS:** Enable if your LDAP server uses **Start TLS** operation.
 * **User Search Filter:** LDAP search filter expression to search for
-the users. For example, `uid={0}` searches for a username that matches with
+the users. For example, `uid=\{0}` searches for a username that matches with
 the `uid` attribute.
 * **Group Search Filter:** LDAP search filter expression to search for
-the groups. For example, `uniquemember={0}` searches for a group that
+the groups. For example, `uniquemember=\{0}` searches for a group that
 matches with the `uniquemember` attribute.
 * **Nested Group Search:** Disable if you have a large LDAP group structure
 and it takes a long time to query all nested groups during login.


### PR DESCRIPTION
Fixes
```
3:58:09 PM: [12:58:09.360] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:09 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:09 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.03 | start path: docs)
3:58:09 PM: [12:58:09.361] WARN (asciidoctor): skipping reference to missing attribute: 1
3:58:09 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:09 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.03 | start path: docs)
3:58:09 PM: [12:58:09.361] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:09 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:09 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.03 | start path: docs)
3:58:09 PM: [12:58:09.367] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:09 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:09 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.03 | start path: docs)
3:58:09 PM: [12:58:09.368] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:09 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:09 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.03 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e97ba4dd50b60008d9236e#L147