### PR TITLE
Fix build warnings v/4.2021.12

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 name: management-center
 title: Hazelcast Management Center
-version: 4.2021.06-SNAPSHOT
-prerelease: true
+version: 4.2021.12
+prerelease: false
 asciidoc:
   attributes:
     javasource: ROOT:example$

--- a/docs/modules/ROOT/pages/connecting-members.adoc
+++ b/docs/modules/ROOT/pages/connecting-members.adoc
@@ -27,3 +27,46 @@ one cluster with the same cluster name.
 NOTE: If the cluster uses
 xref:imdg:clusters:advanced-network-configuration.adoc[Advanced Network],
 then the provided member address should be the client address of the member.
+
+
+== Configuring Security on the Members
+
+NOTE: This section applies only to IMDG 4.2 and newer. If you use an older version, you can skip this configuration step.
+
+If `security` is enabled in the member configurations, then the `management-permission` should be granted for the Management Center client. Also, in this case the client should authenticate itself, which means you need to set up the connection by uploading a configuration XMl (or YAML): see xref:ROOT:managing-clusters.adoc#creating-a-cluster-configuration-by-uploading-file[here].
+
+An example member configuration is shown below:
+
+```xml
+<hazelcast xmlns="http://www.hazelcast.com/schema/config">
+    <security enabled="true">
+        <realms>
+            <realm name="client-realm">
+                <authentication>
+                    ...
+                </authentication>
+            </realm>
+        </realms>
+        <client-authentication realm="client-realm" />
+        <client-permissions>
+            <management-permission principal="mcadmin" />
+        </client-permissions>
+    </security>
+</hazelcast>
+
+```
+
+An example client configuration is shown below:
+
+```xml
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+    <cluster-name>dev</cluster-name>
+
+    <security>
+        <username-password username="mcadmin" password="mypassword"/>
+    </security>
+</hazelcast-client>
+```

--- a/docs/modules/ROOT/pages/mc-conf.adoc
+++ b/docs/modules/ROOT/pages/mc-conf.adoc
@@ -10,6 +10,9 @@ NOTE: You must run the MC-Conf tool on the same machine where the Management Cen
 
 NOTE: The Management Center must not be running when changes are made via MC-Conf.
 
+NOTE: If you have used a non-default Management Center home directory location,
+then you must provide the path to the home directory with the `-H` (or `--home`) option.
+
 == Built-In Help
 
 In order to see all available commands, run the MC-Conf script with no
@@ -99,8 +102,6 @@ Note that you must stop the Management Center web application before running thi
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual cluster connection configuration through UI.
 
-NOTE: If you have used a non-default Management Center home directory location, you must provide the path to the home directory with the `-H` (or `--home`) option.
-
 [[mc-conf-create-user]]
 == Creating Users
 
@@ -113,8 +114,6 @@ https://github.com/hazelcast/hazelcast-docker-samples[Hazelcast Docker Code Samp
 repository for an example of Docker image for the Management Center container with
 a built-in user account.
 
-NOTE: If you have used a non-default Management Center home directory location, then you must provide the path to the home directory with the `-H` (or `--home`) option.
-
 NOTE: If you're on Linux or MacOS devices and provide value directly to `mc-conf`, please enclose password in single quotes like: `-p='mysecr3tp@s$word'`
 
 == Changing User Password
@@ -125,8 +124,6 @@ web application before running this task.
 
 You can use this task as a recovery mechanism for the Management Center's
 administrator user account.
-
-NOTE: If you have used a non-default Management Center home directory location, you must provide the path to the home directory with the `-H` (or `--home`) option.
 
 NOTE: If you're on Linux or MacOS devices and provide value directly to `mc-conf`, please enclose password in single quotes like: `-p='mysecr3tp@s$word'`
 
@@ -154,9 +151,6 @@ Note that if the keystore with such path doesn't exist, task fails.
 NOTE: You still need to properly configure Management Center to use keystore.
 See xref:launching:auth-options.adoc#password-encryption[LDAP Authentication section] for details on using the built-in and existing keystores.
 
-NOTE: If you have used a non-default Management Center home directory location,
-then you must provide the path to the home directory with the `-H` (or `--home`) option.
-
 [[mc-conf-update-ldap-password]]
 == Updating LDAP Password
 
@@ -174,8 +168,6 @@ Note that you must stop the Management Center web application before running thi
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
 
-NOTE: If you have used a non-default Management Center home directory location, then you must provide the path to the home directory with the `-H` (or `--home`) option.
-
 == Configuring JAAS Security Provider
 
 The `jaas configure` task configures the JAAS security provider.
@@ -183,16 +175,12 @@ Note that you must stop the Management Center web application before running thi
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
 
-NOTE: If you have used a non-default Management Center home directory location, then you must provide the path to the home directory with the `-H` (or `--home`) option.
-
 == Configuring Dev Mode Security Provider
 
 The `dev-mode` configure task configures the Dev Mode security provider.
 Note that you must stop the Management Center web application before running this task.
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
-
-NOTE: If you have used a non-default Management Center home directory location, then you must provide the path to the home directory with the `-H` (or `--home`) option.
 
 == Resetting Security Provider
 
@@ -205,14 +193,16 @@ You can use this task as a recovery mechanism for the Management Center deployme
 In case of the Local security provider, you can also use the `user create` or `user update-password`
 task as the recovery mechanism.
 
-NOTE: If you have used a non-default Management Center home directory location, then you must
-provide the path to the home directory with the `-H` (or `--home`) option.
-
 == Enabling/Disabling Metrics Persistence
 
 The `set metrics-persistence-enabled` task lets you choose whether
-metrics should be persisted to disk or not. Note that you must stop the Management
-Center web application before running this task.
+metrics should be persisted to disk or not.
+
+== Hiding Sensitive Configuration Properties
+
+The `set sensitive-properties` task configures the sensitive properties that must not be shown in plain text in Management Center.
+`--hidden-properties` is a comma-separated list of member properties to be hidden in the member properties.
+`--masked-config-properties` is a comma-separated list of XPath expressions in the member configuration to be masked.
 
 == Advanced Features
 

--- a/docs/modules/ROOT/pages/mc-conf.adoc
+++ b/docs/modules/ROOT/pages/mc-conf.adoc
@@ -98,7 +98,6 @@ Create a new user record in the Local security provider.
 == Configuring Cluster Connection
 
 The `cluster add` task adds a new connection configuration for a cluster.
-Note that you must stop the Management Center web application before running this task.
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual cluster connection configuration through UI.
 
@@ -164,21 +163,30 @@ on the **Reload Security Config** button on the login page.
 == Configuring Active Directory Security Provider
 
 The `active-directory configure` task configures the Active Directory security provider.
-Note that you must stop the Management Center web application before running this task.
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
 
 == Configuring JAAS Security Provider
 
 The `jaas configure` task configures the JAAS security provider.
-Note that you must stop the Management Center web application before running this task.
+
+You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
+
+== Configuring OpenID Connect Security Provider
+
+The `oidc configure` task configures the OpenID Connect security provider.
+
+You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
+
+== Configuring SAML Security Provider
+
+The `saml configure` task configures the SAML security provider.
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
 
 == Configuring Dev Mode Security Provider
 
 The `dev-mode` configure task configures the Dev Mode security provider.
-Note that you must stop the Management Center web application before running this task.
 
 You can use this task for various scripting purposes, and automatically configuring Management Center, without the need for a manual security provider configuration through UI.
 

--- a/docs/modules/launching/pages/auth-options.adoc
+++ b/docs/modules/launching/pages/auth-options.adoc
@@ -52,10 +52,10 @@ Provide the details in this form for your Active Directory server:
 schema (`ldap://` or `ldaps://`) and port.
 * **Domain:** Domain of your organization on Active Directory.
 * **User Search Filter:** LDAP search filter expression to search
-for the users. `{0}` will be replaced with `username@domain` and
-`{1}` will be replaced with only the `username`. You can use both
+for the users. `\{0}` will be replaced with `username@domain` and
+`\{1}` will be replaced with only the `username`. You can use both
 placeholders, only one of them or none in your search filter. For
-example, `(&(objectClass=user)(userPrincipalName={0}))` searches
+example, `(&(objectClass=user)(userPrincipalName=\{0}))` searches
 for a username that matches with the `userPrincipalName` attribute
 and member of the object class `user`.
 * **Admin Group(s):** Members of this group and its nested groups
@@ -258,10 +258,10 @@ have the privilege to see only the metrics on the Management Center.
 To use more than one group, separate them with a semicolon (;).
 * **Start TLS:** Enable if your LDAP server uses **Start TLS** operation.
 * **User Search Filter:** LDAP search filter expression to search for
-the users. For example, `uid={0}` searches for a username that matches with
+the users. For example, `uid=\{0}` searches for a username that matches with
 the `uid` attribute.
 * **Group Search Filter:** LDAP search filter expression to search for
-the groups. For example, `uniquemember={0}` searches for a group that
+the groups. For example, `uniquemember=\{0}` searches for a group that
 matches with the `uniquemember` attribute.
 * **Nested Group Search:** Disable if you have a large LDAP group structure
 and it takes a long time to query all nested groups during login.

--- a/docs/modules/monitor-imdg/pages/monitor-dds.adoc
+++ b/docs/modules/monitor-imdg/pages/monitor-dds.adoc
@@ -66,7 +66,7 @@ image:ROOT:MapBrowserWithCustomTypedValue.png[Map Browser with Custom Typed Valu
 === Map Config
 
 Use the Map Config tool to set the selected map's attributes, such
-as the backup count, TTL, and eviction policy. To open the Map Config
+as the max size, TTL, and eviction policy. To open the Map Config
 tool, click on the **Map Config** button, located at the top right of
 the window. Once opened, the tool appears as a dialog, as shown below.
 


### PR DESCRIPTION
Fixes
```
3:58:12 PM: [12:58:12.056] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:12 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:12 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.12 | start path: docs)
3:58:12 PM: [12:58:12.057] WARN (asciidoctor): skipping reference to missing attribute: 1
3:58:12 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:12 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.12 | start path: docs)
3:58:12 PM: [12:58:12.057] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:12 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:12 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.12 | start path: docs)
3:58:12 PM: [12:58:12.061] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:12 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:12 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.12 | start path: docs)
3:58:12 PM: [12:58:12.061] WARN (asciidoctor): skipping reference to missing attribute: 0
3:58:12 PM:     file: docs/modules/launching/pages/auth-options.adoc
3:58:12 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/4.2021.12 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e97ba4dd50b60008d9236e#L192