### PR TITLE
Fix build warnings v/5.2

### DIFF
--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -581,7 +581,7 @@ hz-mc start -Dhazelcast.mc.ad.ssl.trustStore=/some/dir/truststore \
 
 ----
 
-|[[hazelcast-mc-ldap-ssl-truststorepassword]]hazelcast.mc.ad.ssl.trustStorePassword
+|[[hazelcast-mc-ad-ssl-truststorepassword]]hazelcast.mc.ad.ssl.trustStorePassword
 
 MC_AD_SSL_TRUST_STORE_PASSWORD
 |Password for the truststore. Default: `' '` (empty).


### PR DESCRIPTION
Fixes
```
3:58:19 PM: [12:58:19.191] WARN (asciidoctor): id assigned to anchor already in use: hazelcast-mc-ldap-ssl-truststorepassword
3:58:19 PM:     file: docs/modules/deploy-manage/pages/system-properties.adoc:584
3:58:19 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/5.2 | start path: docs)
```

https://app.netlify.com/sites/nifty-wozniak-71a44b/deploys/66e97ba4dd50b60008d9236e#L237