### PR TITLE
Fix build warnings v/5.5

### DIFF
--- a/docs/modules/deploy-manage/pages/h2-upgrade.adoc
+++ b/docs/modules/deploy-manage/pages/h2-upgrade.adoc
@@ -11,7 +11,7 @@ From 5.4.0, an additional `h2-upgrade-cli-*.jar` is included, which is impicitly
 
 If you use custom scripts to run Management Center and they don't call `./bin/hz-mc start`, you must upgrade and migrate H2 data manually.
 
-The new `hz-mc upgrade-h2` command runs all migrations for you and migrates data from `${MC_HOME}/sql` to `${MC_HOME}/metadata`. During migration, some additional folders are created for troubleshooting purposes; these include `sql.backup` and `sql.migrated.${timestamp}`. These additional folders can be safely deleted after successful migration.
+The new `hz-mc upgrade-h2` command runs all migrations for you and migrates data from `$\{MC_HOME}/sql` to `$\{MC_HOME}/metadata`. During migration, some additional folders are created for troubleshooting purposes; these include `sql.backup` and `sql.migrated.$\{timestamp}`. These additional folders can be safely deleted after successful migration.
 If you have customized the Management Center home directory, ensure that the `MC_HOME` environment variable has been configured before calling `hz-mc upgrade-h2`
 For example:
 ```bash

--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -681,7 +681,7 @@ hz-mc start -Dhazelcast.mc.ad.ssl.trustStore=/some/dir/truststore \
 
 ----
 
-|[[hazelcast-mc-ldap-ssl-truststorepassword]]hazelcast.mc.ad.ssl.trustStorePassword
+|[[hazelcast-mc-ad-ssl-truststorepassword]]hazelcast.mc.ad.ssl.trustStorePassword
 
 MC_AD_SSL_TRUST_STORE_PASSWORD
 |Password for the truststore. Default: `' '` (empty).


### PR DESCRIPTION
```
3:58:25 PM: [12:58:25.163] WARN (asciidoctor): skipping reference to missing attribute: mc_home
3:58:25 PM:     file: docs/modules/deploy-manage/pages/h2-upgrade.adoc
3:58:25 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/5.5 | start path: docs)
3:58:25 PM: [12:58:25.163] WARN (asciidoctor): skipping reference to missing attribute: mc_home
3:58:25 PM:     file: docs/modules/deploy-manage/pages/h2-upgrade.adoc
3:58:25 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/5.5 | start path: docs)
3:58:25 PM: [12:58:25.163] WARN (asciidoctor): skipping reference to missing attribute: timestamp
3:58:25 PM:     file: docs/modules/deploy-manage/pages/h2-upgrade.adoc
3:58:25 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/5.5 | start path: docs)
3:58:25 PM: [12:58:25.658] WARN (asciidoctor): id assigned to anchor already in use: hazelcast-mc-ldap-ssl-truststorepassword
3:58:25 PM:     file: docs/modules/deploy-manage/pages/system-properties.adoc:684
3:58:25 PM:     source: https://github.com/hazelcast/management-center-docs (branch: v/5.5 | start path: docs)
```