### PR TITLE
Use latest `v4` of GitHub Actions

### DIFF
--- a/.github/workflows/action-updater.yml
+++ b/.github/workflows/action-updater.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.4
+      - uses: actions/checkout@v4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ACTION_UPDATER }}

--- a/.github/workflows/backport-5.0.yml
+++ b/.github/workflows/backport-5.0.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5.1.yml
+++ b/.github/workflows/backport-5.1.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5.2.yml
+++ b/.github/workflows/backport-5.2.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5.3.yml
+++ b/.github/workflows/backport-5.3.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5.4.yml
+++ b/.github/workflows/backport-5.4.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-5.5.yml
+++ b/.github/workflows/backport-5.5.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/backport-to-beta.yml
+++ b/.github/workflows/backport-to-beta.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     
       - name: checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
          fetch-depth: 0
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.4
-    - uses: actions/setup-node@v4.0.2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 16
     - name: Check for broken internal links


### PR DESCRIPTION
Following on from https://github.com/hazelcast/hz-docs/pull/1316, all GitHub actions should use the latest `v4` rather than some hardcoded sub-version.