### PR TITLE
Fix `backport-5.5.yml`

### DIFF
--- a/.github/workflows/backport-5.5.yml
+++ b/.github/workflows/backport-5.5.yml
@@ -1,4 +1,4 @@
-cname: Backport changes to version 5.5
+name: Backport changes to version 5.5
 on:
  push:
   branches:


### PR DESCRIPTION
Syntax error causing [execution failure](https://github.com/hazelcast/management-center-docs/actions/runs/11289108705):
> The workflow is not valid. .github/workflows/backport-5.5.yml (Line: 1, Col: 1): Unexpected value 'cname'