### PR TITLE
Update Version Variables on antora.yml  

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -8,11 +8,11 @@ prerelease: true
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '6.0-SNAPSHOT'
+    full-version: '5.5.2'
     # Version to be used when installing a Hazelcast cluster
-    hz-full-version: '5.4.0-SNAPSHOT'
+    hz-full-version: '5.5.2'
     # Version to be used when installing a snapshot using brew
-    version-brew: '5.3.1.SNAPSHOT'
+    version-brew: '5.5.2'
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'


### PR DESCRIPTION
Updated `full-version`, `hz-full-version`, and `version-brew` to latest stable `5.5.2`