### PR TITLE
Update `CODEOWNERS` to use `documentation` group [DOC-256]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hazelcast/documentation


### PR DESCRIPTION
Ensure consistency across all doc repos

Fixes: [DOC-256](https://hazelcast.atlassian.net/browse/DOC-256)