### PR TITLE
Set `page-latest-supported-hazelcast` correctly in `v/5.6'

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -14,7 +14,7 @@ asciidoc:
     version-brew: '5.5.2'
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast: '6.0-snapshot'
+    page-latest-supported-hazelcast: '5.5'
     # https://github.com/hazelcast/clc/releases
     page-latest-supported-clc: '5.4.1'
     page-toclevels: 1


### PR DESCRIPTION
In https://github.com/hazelcast/management-center-docs/pull/360, `page-latest-supported-hazelcast` was incorrectly incremented.

Although Hazelcast's `main` branches had upgraded to `v6`, Management Center's `main` branch was still targeting `v5` with new releases - meaning `v5.6` docs' URLs are pointing at `6.0.0-SNAPSHOT` documentation.

Now that [`management-center-docs` is `v6`](https://github.com/hazelcast/management-center-docs/commit/adec11cd84dff1c0dabd541ef6afccccb1a38efb), this is no longer an issue on `main`, and can simply be reverted on a maintenance branch.

[Slack discussion](https://hazelcast.slack.com/archives/C035HQET5/p1732814748534219).