### PR TITLE
Use GitHub runners as public repo

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     steps:
       - name: Dispatch docs deployment
         #   https://docs.netlify.com/configure-builds/build-hooks/


### PR DESCRIPTION
Based on our [runner selection documentation](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/5358485538/GitHub+Runner+Selection+Guide), we should be using the GitHub runners for actions executed in public repos as they are free vs using paid-for `ubicloud` minutes.