### PR TITLE
Fixing updated metric name in Prometheus metrics

### DIFF
--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -264,7 +264,7 @@ In some cases, several original metrics are combined into one and differentiated
 |Number of remove operations performed on the index
 
 |map_index_totalInsertLatency
-|map_index_latency_total
+|map_index_latency_total_seconds
 |insert
 |Total latency of insert operations performed on the index
 


### PR DESCRIPTION
Fixing updated value for map_index_totalInsertLatency. It should be map_index_latency_total_seconds. (ref. SF case: 14639)