### PR TITLE
add minor version variable

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -9,6 +9,8 @@ asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
     full-version: '6.0.0-SNAPSHOT'
+    # The minor.patch version, which is used as a variable in the docs for things like file versions
+    minor-version: '6.0-SNAPSHOT'
     # Version to be used when installing a Hazelcast cluster
     hz-full-version: '5.5.2'
     snapshot: true


### PR DESCRIPTION
https://github.com/hazelcast/hz-docs/pull/1582 changes to use the minor-version variable. A chunk of the updated content is included in getting-started/pages/overview.adoc, so the MC docs need this variable defined too.

Fixes error https://github.com/hazelcast/hz-docs/actions/runs/13586317836/job/37981987185?pr=1582.