### PR TITLE
Remove `hz-full-version` property

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -9,8 +9,6 @@ asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
     full-version: '6.0.0-SNAPSHOT'
-    # Version to be used when installing a Hazelcast cluster
-    hz-full-version: '5.5.2'
     snapshot: true
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'

--- a/docs/modules/getting-started/pages/get-started.adoc
+++ b/docs/modules/getting-started/pages/get-started.adoc
@@ -44,7 +44,7 @@ ifdef::snapshot[]
 version: "3.8"
 services:
   hazelcast:
-    image: hazelcast/hazelcast:{hz-full-version}
+    image: hazelcast/hazelcast:latest
     ports:
     - "5701:5701"
   management-center:
@@ -62,7 +62,7 @@ ifndef::snapshot[]
 version: "3.8"
 services:
   hazelcast:
-    image: hazelcast/hazelcast:{hz-full-version}
+    image: hazelcast/hazelcast:latest
     ports:
     - "5701:5701"
   management-center:


### PR DESCRIPTION
MC docs contain a reference to Hazelcast platform version, but this has some issues:
- it's _sometimes_ manually updated but not part of a checklist to ensure it always is
- it's outdated
- EE and OS versions are different so a single Hazelcast version doesn't make sense
- It's been set to an EE version but it's being _used_ like an OS version - the `hazelcast/hazelcast:5.5.2` Docker image does not exist

[MC is backwards compatible with older Hazelcast versions](https://hazelcast.slack.com/archives/C9S7BV74Z/p1738850869425519) - I assume the inverse is true, so in that case `latest` seems the most sensible and easiest to maintain.

Whether we should backport this change is up for discussion - it won't backport "cleanly" due to conflicts and no-one has reported this as an issue.