### PR TITLE
Remove Hazelcast `SNAPSHOT` reference from production docs

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -14,7 +14,7 @@ asciidoc:
     version-brew: '5.5.2'
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
-    page-latest-supported-hazelcast: '6.0-snapshot'
+    page-latest-supported-hazelcast: '5.5'
     # https://github.com/hazelcast/clc/releases
     page-latest-supported-clc: '5.4.1'
     page-toclevels: 1


### PR DESCRIPTION
We should not be referencing a `SNAPSHOT` version in production docs.