### PR TITLE
Fix `hazelcast-full-example` config file links

### DIFF
--- a/docs/modules/clusters/pages/update-config.adoc
+++ b/docs/modules/clusters/pages/update-config.adoc
@@ -28,9 +28,9 @@ ifdef::snapshot[]
 - https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/resources/hazelcast-full-example.yaml[YAML example]
 endif::[]
 ifndef::snapshot[]
-- link:https://github.com/hazelcast/hazelcast/tree/{page-latest-supported-hazelcast}.z/hazelcast/src/main/resources/hazelcast-full-example.xml[XML example]
+- link:https://github.com/hazelcast/hazelcast/tree/v{page-latest-supported-hazelcast}.0/hazelcast/src/main/resources/hazelcast-full-example.xml[XML example]
 
-- link:https://github.com/hazelcast/hazelcast/tree/{page-latest-supported-hazelcast}.z/hazelcast/src/main/resources/hazelcast-full-example.yaml[YAML example]
+- link:https://github.com/hazelcast/hazelcast/tree/v{page-latest-supported-hazelcast}.0/hazelcast/src/main/resources/hazelcast-full-example.yaml[YAML example]
 endif::[]
 
 == Submitting New Configuration to the Cluster 


### PR DESCRIPTION
The links to `hazelcast-full-example` config files go to the maintenance `z` branch(es) of the `hazelcast` repo which no longer exist.

There's not a direct replacement, but as a workaround we can simply assume that the `.0` patch version of that releases source code is publicly accessible and reference that instead.

In `hz-docs` we avoid this issue by having explicit OS/EE versions but introducing here adds more properties to maintain.