### PR TITLE
Remove Docker compose obselete `version` attribute

### DIFF
--- a/docs/modules/getting-started/pages/get-started.adoc
+++ b/docs/modules/getting-started/pages/get-started.adoc
@@ -41,7 +41,6 @@ If you do not see a version number, see the link:https://docs.docker.com/get-sta
 ifdef::snapshot[]
 [source,yaml,subs="attributes+"]
 ----
-version: "3.8"
 services:
   hazelcast:
     image: hazelcast/hazelcast:{hz-full-version}
@@ -59,7 +58,6 @@ endif::[]
 ifndef::snapshot[]
 [source,bash,subs="attributes+"]
 ----
-version: "3.8"
 services:
   hazelcast:
     image: hazelcast/hazelcast:{hz-full-version}


### PR DESCRIPTION
Addresses warning:
```
attribute `version` is obsolete
```

https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete