### PR TITLE
Updated outdated CLC version

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -14,7 +14,7 @@ asciidoc:
     page-latest-supported-imdg: '4.2'
     page-latest-supported-hazelcast: '6.0-snapshot'
     # https://github.com/hazelcast/clc/releases
-    page-latest-supported-clc: '5.4.1'
+    page-latest-supported-clc: '5.6.0'
     page-toclevels: 1
     experimental: true
 nav:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,8 +13,8 @@ asciidoc:
     javasource: ROOT:example$
     page-latest-supported-imdg: '4.2'
     page-latest-supported-hazelcast: '6.0-snapshot'
-    # https://github.com/hazelcast/clc/releases
-    page-latest-supported-clc: '5.6.0'
+    # https://github.com/hazelcast/hazelcast-commandline-client/releases
+    page-latest-supported-clc: '5.5.0'
     page-toclevels: 1
     experimental: true
 nav:


### PR DESCRIPTION
The CLC version in the docs is outdated.

Note this step is listed in the [CLC release process](https://hazelcast.atlassian.net/wiki/spaces/HZC/pages/3731193857/Commandline+Client+Releases).

Unsure version compatibility ranges to determine appropriate backport.