### PR TITLE
[EMGR-438] Define V1 and V2 Metrics and their Differences

### DIFF
--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -6,10 +6,10 @@
 
 By default, Management Center exposes two versions of metrics:
 
-* Version 1 (V1) Metrics. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
+* *Version 1 (V1) Metrics.* Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
 ** Substitutes `.` for `_`
 ** Adds the prefix `hz_`
-* Version 2 (V2) Metrics. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
+* *Version 2 (V2) Metrics.* Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
 ** Use `snake_case`
 ** Add `hazelcast_` prefix
 ** Update metric names where appropriate

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -7,21 +7,20 @@
 By default, Management Center exposes two versions of metrics:
 
 * Version 1 (V1) Metrics. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
-  * Substitutes `.` for `_`
-  * Adds the prefix `hz_`
+** Substitutes `.` for `_`
+** Adds the prefix `hz_`
 * Version 2 (V2) Metrics. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
-  * Use `snake_case`
-  * Add `hazelcast_` prefix
-  * Update metric names where appropriate
-  * Combine related metrics and add labels
-  * Convert to recommended base units:
-  ** Time in seconds
-  ** Memory in bytes
-  ** Percentages as ratios (for example, 50% converts to 0.5)
-  * Append units to metric names
-  * Remove unit labels
-  * Append `_total` to accumulated metrics
-  * Rename and remove `unit` label, add `_total` suffix:
+** Use `snake_case`
+** Add `hazelcast_` prefix
+** Update metric names where appropriate
+** Combine related metrics and add labels
+** Convert to recommended base units:
+** Time in seconds
+** Memory in bytes
+** Percentages as ratios (for example, 50% converts to 0.5)
+** Append units to metric names
+** Remove unit labels
+** Append `_total` to accumulated metrics
 
 We currently publish by default V1 and V2 metrics.
 
@@ -29,6 +28,7 @@ We currently publish by default V1 and V2 metrics.
 
 The following examples illustrate the differences between the V1 and V2 metrics.
 
+* Rename and remove `unit` label, add `_total` suffix:
 +
 ```
 # V1

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -4,76 +4,72 @@
 
 {description}
 
-By default, Management Center exposes both the original metrics and the updated versions. Existing integrations will therefore continue to work, but you should consider the original metrics deprecated and plan to migrate to the updated versions. You can optionally xref:config[change which set of metrics is exposed].
+By default, Management Center exposes two versions of metrics:
 
-== Metrics changes
+* Version 1 (V1) Metrics. Take the metrics exposed by Hazelcast's JMX metrics system and applies the following transformation to each of the metric names:
+  * Substitutes `.` for `_`
+  * Adds the prefix `hz_`
+* Version 2 (V2) Metrics. Take the metrics exposed by Hazelcast's JMX metrics system but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
+  * Use `snake_case`
+  * Add `hazelcast_` prefix
+  * Update metric names where appropriate
+  * Combine related metrics and add labels
+  * Convert to recommended base units:
+  ** Time in seconds
+  ** Memory in bytes
+  ** Percentages as ratios (for example, 50% converts to 0.5)
+  * Append units to metric names
+  * Remove unit labels
+  * Append `_total` to accumulated metrics
+  * Rename and remove `unit` label, add `_total` suffix:
 
-Management Center makes the following changes to metrics exposed by Hazelcast clusters.
+We currently publish by default V1 and V2 metrics; however, the V1 metrics are marked for deprecation and will be removed in an upcoming release of Management Centre.
 
-Original metrics:
+The following examples illustrate the differences between the V1 and V2 metrics.
 
-* Convert `.` to `_`
-* Add `hz_` prefix
-
-Updated metrics:
-
-* Use `snake_case`
-* Add `hazelcast_` prefix
-* Update metric names where appropriate
-* Combine related metrics and add labels
-* Convert to recommended base units:
-** Time in seconds
-** Memory in bytes
-** Percentages as ratios (for example, 50% converts to 0.5)
-* Append units to metric names
-* Remove unit labels
-* Append `_total` to accumulated metrics
-
-The updated metrics are based on link:https://prometheus.io/docs/practices/naming/[Prometheus conventions].
-
-The following examples illustrate the differences between the original and updated metrics.
-
-* Rename and remove `unit` label, add `_total` suffix:
 +
 ```
+# V1
 hz_map_queryCount{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",unit="COUNT",} 0.0 1737715903399
-
+# V2
 hazelcast_map_queries_total{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",} 0.0 1737715903399
 ```
 
 * Rename and append unit, remove `unit` label, convert value (1.7x10^12^ milliseconds to 1.7x10^9^ seconds):
 +
 ```
+# V1
 hz_map_creationTime{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",unit="MS",} 1.737715861118E12 1737715903399
-
+# V2
 hazelcast_map_creation_timestamp_seconds{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",} 1.737715861118E9 1737715903399
 ```
 
 * Rename and append unit, remove `unit` label, add `remove` label:
 +
 ```
+# V1
 hz_map_totalMaxRemoveLatency{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",unit="MS",} 0.0 1737715903399
-
+# V2
 hazelcast_map_latency_max_seconds{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",operation="remove",} 0.0 1737715903399
 ```
 
 * Rename, append unit suffix and `_total` suffix, remove `unit` label, add `remove` label, convert value from milliseconds to seconds:
 +
 ```
+# V1
 hz_map_totalPutLatency{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",unit="MS",} 2019.0 1743601193973
-
+# V2
 hazelcast_map_latency_seconds_total{name="map-1",mc_member="127.0.0.1:5701",mc_cluster="Cluster-1",operation="put",} 2.019 1743601193973
 ```
 
-
 [[config]]
-== Choose which set of metrics to use
+== Configuring the Metrics Version
 
-To change which set of metrics is exposed to Prometheus, update the `hazelcast.mc.prometheusExporter.printers` system property:
+You can tell Management Centre which metrics version to export by defining the system property `hazelcast.mc.prometheusExporter.printers` as follows:
 
-* Original only: `hazelcast.mc.prometheusExporter.printers=V1`
-* Updated only: `hazelcast.mc.prometheusExporter.printers=V2`
-* Both (default): `hazelcast.mc.prometheusExporter.printers=V1,V2`
+* V1: `hazelcast.mc.prometheusExporter.printers=V1`
+* V2: `hazelcast.mc.prometheusExporter.printers=V2`
+* V1 and V2 (default): `hazelcast.mc.prometheusExporter.printers=V1,V2`
 
 See xref:deploy-manage:system-properties.adoc[].
 
@@ -83,13 +79,13 @@ IMPORTANT: If you set the property to `V2`, Management Center will only expose t
 
 Management Center converts all metrics for the `map`, `set` and `list` data structures. The full xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[list of Hazelcast metrics] is provided in the Hazelcast Platform documentation.
 
-In some cases, several original metrics are combined into one and differentiated by labels. For example, `hazelcast_map_operations_total` replaces `hz_map_getCount` and `hz_map_setCount` by adding `operation="get"` and `operation="set"` labels.
+In some cases, several V1 metrics are combined into a single V2 metric differentiated by labels. For example, `hazelcast_map_operations_total` replaces `hz_map_getCount` and `hz_map_setCount` by adding `operation="get"` and `operation="set"` labels.
 
 .Map
 [%collapsible]
 ====
 |===
-|Original metric `hz_` |Updated metric `hazelcast_` |Additional labels |Description 
+|V1 Metric |V2 Metric |Additional Labels |Description 
 
 |map_backupCount
 |map_backups_total
@@ -302,7 +298,7 @@ In some cases, several original metrics are combined into one and differentiated
 [%collapsible]
 ====
 |===
-|Original metric `hz_` |Updated metric `hazelcast_` |Additional labels |Description
+|V1 Metric |V2 Metric |Additional Labels |Description
 |set_creationTime
 |set_creation_timestamp_seconds
 |n/a
@@ -324,7 +320,7 @@ In some cases, several original metrics are combined into one and differentiated
 [%collapsible]
 ====
 |===
-|Original metric `hz_` |Updated metric `hazelcast_` |Additional labels |Description
+|V1 Metric |V2 Metric |Additional Labels |Description
 |list_creationTime
 |list_creation_timestamp_seconds
 |n/a

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -9,7 +9,7 @@ By default, Management Center exposes two versions of metrics:
 * *Version 1 (V1) Metrics.* Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
 ** Substitutes `.` for `_`
 ** Adds the prefix `hz_`
-* *Version 2 (V2) Metrics.* Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
+* *Version 2 (V2) Metrics.* _Currently in BETA_. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
 ** Use `snake_case`
 ** Add `hazelcast_` prefix
 ** Update metric names where appropriate
@@ -23,8 +23,6 @@ By default, Management Center exposes two versions of metrics:
 ** Append `_total` to accumulated metrics
 
 We currently publish by default V1 and V2 metrics.
-
-:NOTE: V2 Metrics are currently BETA.
 
 The following examples illustrate the differences between the V1 and V2 metrics.
 

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -23,7 +23,9 @@ By default, Management Center exposes two versions of metrics:
   * Append `_total` to accumulated metrics
   * Rename and remove `unit` label, add `_total` suffix:
 
-We currently publish by default V1 and V2 metrics; however, the V1 metrics are marked for deprecation and will be removed in an upcoming release of Management Center.
+We currently publish by default V1 and V2 metrics.
+
+:NOTE: V2 Metrics are currently BETA.
 
 The following examples illustrate the differences between the V1 and V2 metrics.
 

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -22,7 +22,6 @@ By default, Management Center exposes two versions of metrics:
 ** Remove unit labels
 ** Append `_total` to accumulated metrics
 
-We currently publish by default V1 and V2 metrics.
 
 The following examples illustrate the differences between the V1 and V2 metrics.
 

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -6,10 +6,10 @@
 
 By default, Management Center exposes two versions of metrics:
 
-* Version 1 (V1) Metrics. Take the metrics exposed by {page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
+* Version 1 (V1) Metrics. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
   * Substitutes `.` for `_`
   * Adds the prefix `hz_`
-* Version 2 (V2) Metrics. Take the metrics exposed by {page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
+* Version 2 (V2) Metrics. Take the metrics exposed by xref:{page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
   * Use `snake_case`
   * Add `hazelcast_` prefix
   * Update metric names where appropriate

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -62,7 +62,7 @@ hazelcast_map_latency_seconds_total{name="map-1",mc_member="127.0.0.1:5701",mc_c
 ```
 
 [[config]]
-== Configuring the Metrics Version
+== Configuring the metrics version
 
 You can tell Management Center which metrics version to export by defining the system property `hazelcast.mc.prometheusExporter.printers` as follows:
 

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -64,7 +64,7 @@ hazelcast_map_latency_seconds_total{name="map-1",mc_member="127.0.0.1:5701",mc_c
 [[config]]
 == Configuring the metrics version
 
-You can tell Management Center which metrics version to export by defining the system property `hazelcast.mc.prometheusExporter.printers` as follows:
+To change which set of metrics is exposed to Prometheus, update the `hazelcast.mc.prometheusExporter.printers` system property:
 
 * V1: `hazelcast.mc.prometheusExporter.printers=V1`
 * V2: `hazelcast.mc.prometheusExporter.printers=V2`

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -23,7 +23,7 @@ By default, Management Center exposes two versions of metrics:
   * Append `_total` to accumulated metrics
   * Rename and remove `unit` label, add `_total` suffix:
 
-We currently publish by default V1 and V2 metrics; however, the V1 metrics are marked for deprecation and will be removed in an upcoming release of Management Centre.
+We currently publish by default V1 and V2 metrics; however, the V1 metrics are marked for deprecation and will be removed in an upcoming release of Management Center.
 
 The following examples illustrate the differences between the V1 and V2 metrics.
 
@@ -65,7 +65,7 @@ hazelcast_map_latency_seconds_total{name="map-1",mc_member="127.0.0.1:5701",mc_c
 [[config]]
 == Configuring the Metrics Version
 
-You can tell Management Centre which metrics version to export by defining the system property `hazelcast.mc.prometheusExporter.printers` as follows:
+You can tell Management Center which metrics version to export by defining the system property `hazelcast.mc.prometheusExporter.printers` as follows:
 
 * V1: `hazelcast.mc.prometheusExporter.printers=V1`
 * V2: `hazelcast.mc.prometheusExporter.printers=V2`

--- a/docs/modules/integrate/pages/prometheus-metrics.adoc
+++ b/docs/modules/integrate/pages/prometheus-metrics.adoc
@@ -6,10 +6,10 @@
 
 By default, Management Center exposes two versions of metrics:
 
-* Version 1 (V1) Metrics. Take the metrics exposed by Hazelcast's JMX metrics system and applies the following transformation to each of the metric names:
+* Version 1 (V1) Metrics. Take the metrics exposed by {page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] and applies the following transformation to each of the metric names:
   * Substitutes `.` for `_`
   * Adds the prefix `hz_`
-* Version 2 (V2) Metrics. Take the metrics exposed by Hazelcast's JMX metrics system but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
+* Version 2 (V2) Metrics. Take the metrics exposed by {page-latest-supported-hazelcast}@hazelcast::list-of-metrics.adoc[Hazelcast's JMX metrics system] but applies transformation to their names so that they conform with link:https://prometheus.io/docs/practices/naming/[Prometheus naming conventions]:
   * Use `snake_case`
   * Add `hazelcast_` prefix
   * Update metric names where appropriate


### PR DESCRIPTION
There's no definition of `V1` and `V2` metrics, only `original` and `updated` which leaves the reader to determine which is `V1` and which is `V2`. `V1` and `V2` are defined in this PR as these are the values that can be configured in the property: `hazelcast.mc.prometheusExporter.printers`.