### PR TITLE
DOC-482-table: add MC Enterprise features table

### DIFF
--- a/docs/modules/deploy-manage/pages/license-management.adoc
+++ b/docs/modules/deploy-manage/pages/license-management.adoc
@@ -6,21 +6,7 @@
 
 == Licensed features
 
-// For a list of Management Center's Enterprise features, see the xref:getting-started:overview.adoc#key-features-and-benefits[Overview].
-
-Management Center requires a valid Enterprise license for the following:
-
-- Clustered JMX
-
-- Clustered REST API
-
-- Cluster Client Filtering
-
-- Prometheus Exporter
-
-- Displaying metrics for more than three cluster members
-
-- Healthcheck
+For a list of Management Center's Enterprise features, see the xref:getting-started:overview.adoc#key-features-and-benefits[Overview].
 
 To use these features, you must install (in Management Center) either an Enterprise license for Management Center or an Enterprise license for Hazelcast Platform.
 

--- a/docs/modules/getting-started/pages/overview.adoc
+++ b/docs/modules/getting-started/pages/overview.adoc
@@ -10,7 +10,85 @@ Using Management Center, you can manage your Hazelcast deployment with a user-fr
 
 While the {open-source-product-name} offers basic functionality for small deployments (up to 3 cluster members), the {enterprise-product-name} unlocks the full potential of Management Center with advanced security, monitoring, and management features. Get a 30-day free trial with no obligation from our https://hazelcast.com/get-started/[Try Hazelcast] page.
 
-To access Enterprise features, an Enterprise license must be installed on Management Center. See xref:deploy-manage:license-management.adoc[].
+NOTE: To access Enterprise features, an Enterprise license must be installed on Management Center. See xref:deploy-manage:license-management.adoc[].
+
+== Key features and benefits
+
+//cols="2a,1a,1a,2a"]
+
+[cols="30%,20%,20%,30%"]
+|===
+|*Real-time monitoring and performance tracking*|*{enterprise-product-name}*|*{open-source-product-name}*|*Description*
+
+|Comprehensive dashboards for monitoring
+|No limits
+|Limited to monitoring clusters up to 3 members
+|Detailed statistics about members, clients and the data structures in real-time are provided to help you identify performance bottlenecks and optimize your applications
+
+
+|Multi-channel monitoring 
+|Included
+|n/a
+|Delivered through secure Clustered REST and JMX capabilities, and secure Prometheus Exporter functionality with authentication support, providing integration into enterprise-grade monitoring solutions
+
+|Prometheus Exporter and Healthcheck
+|Included
+|n/a
+|Prometheus Exporter provides all the metrics from the cluster in a Prometheus format. Config allows for the metrics to be filtered. Also included are Config Healthcheck counters
+
+|*Powerful administrative tools*|*{enterprise-product-name}*|*{open-source-product-name}*|*Description*
+|Client Filtering
+|Included
+|n/a
+|Allows you to control which clients can connect to a cluster; essential for Blue/Green or Red/Black deployments
+
+|Config Healthcheck
+|Included
+|n/a
+|Lets you identify and diagnose issues in clusters. Config Healthcheck runs automatically when cluster topology or member configuration changes
+
+|Integrated tooling
+|Included
+|Included
+|Integrated tooling from Console, Command Line Client and scripting
+
+|Diagnostics
+|Included
+|Included
+|Allows you to check performance and memory usage. Admin user can take thread dumps
+
+|*Enterprise-grade security and integration*|*{enterprise-product-name}*|*{open-source-product-name}*|*Description*
+|Local User Security
+|Included
+|Included
+|User management with Role-Based Access Control (RBAC) provides several user roles (Admin, User, Read-Only, and Metrics-Only) with varying permissions for different operations
+
+|Third-party authentication
+|Included
+|n/a
+|Extends the RBAC integration with support for third-party authentication services, including JAAS, LDAP, Active Directory, SAML and OpenID
+
+|Audit logs
+|Included
+|n/a
+|Track administrative actions for compliance
+
+|*SQL queries*|*{enterprise-product-name}*|*{open-source-product-name}*|*Description*
+|SQL Browser to execute queries
+|Includes the ability to use SQL DML statements such as CREATE MAPPING, INSERT INTO, and SINK INTO in the SQL Browser
+|Included up to cluster of 3 members
+|Enables you to execute SQL queries on your clusters. Management Center shows queryable objects with a schema and index explorer, and can handle streaming SQL queries, displaying the last 1,000 entries as they arrive
+
+|High availability deployments
+|Included
+|n/a
+|Support for high availability deployments where multiple Management Center instances can connect to the same cluster, eliminating a single point of failure for management and monitoring purposes
+
+|Easy deployment with Docker
+|Included
+|Included
+|Get started quickly with Management Center using Docker Compose. For example, create a docker-compose.yml file to run both Hazelcast and Management Center containers, with Management Center automatically connecting to the Hazelcast cluster
+|===
 
 NOTE: For information about xref:{page-latest-supported-hazelcast}@hazelcast:ROOT:whats-new.adoc[What's new], see the Hazelcast Platform documentation.
 


### PR DESCRIPTION
Create a features and benefits table in the Overview to showcase MC's Enterprise features. 
Removed the list of Enterprise features buried under the licensing topic to avoid duplication/being out of step, and linked to the new table.
