### PR TITLE
Licensing typo fix

### DIFF
--- a/docs/modules/getting-started/pages/get-started.adoc
+++ b/docs/modules/getting-started/pages/get-started.adoc
@@ -81,7 +81,7 @@ Followed by:
 === Start the compose stack with an Enterprise license
 
 If you have an Enterprise Edition license, you can configure the Docker Compose file with the license as follows (see xref:deploy-manage:system-properties.adoc#starting-with-a-license[`hazelcast.mc.license` property] for more details):
-+
+
 [source,yaml,subs="attributes+"]
 ----
 services:

--- a/docs/modules/getting-started/pages/get-started.adoc
+++ b/docs/modules/getting-started/pages/get-started.adoc
@@ -82,7 +82,7 @@ Followed by:
 
 If you have an Enterprise Edition license, you can configure the Docker Compose file with the license as follows (see xref:deploy-manage:system-properties.adoc#starting-with-a-license[`hazelcast.mc.license` property] for more details):
 +
-[source,bash,subs="attributes+"]
+[source,yaml,subs="attributes+"]
 ----
 services:
   hazelcast:


### PR DESCRIPTION
The compose section was set as "bash" instead of "yaml"