### PR TITLE
Remove explicit cURL `POST`

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - name: Dispatch docs deployment
         #   https://docs.netlify.com/configure-builds/build-hooks/
-        run: curl -X POST -d {} https://api.netlify.com/build_hooks/6001915875dde5f2ff105296
+        run: curl -d {} https://api.netlify.com/build_hooks/6001915875dde5f2ff105296
 


### PR DESCRIPTION
When executed with `verbose`, cURL logs:
> Note: Unnecessary use of -X or --request, POST is already inferred.

[The `-d`/`--data` flag sends data via `POST`](https://curl.se/docs/manpage.html#-d) so specifying `POST` _as well_ is redundant.