### PR TITLE
Correcting fully qualified name of the PropertiesLauncher class [v/5.4]

### DIFF
--- a/docs/modules/deploy-manage/pages/variable-replacers.adoc
+++ b/docs/modules/deploy-manage/pages/variable-replacers.adoc
@@ -32,7 +32,7 @@ java -cp hazelcast-management-center-{full-version}.jar \ <1>
      -Dhazelcast.mc.configReplacer.prop.passwordUserProperties=false \ <2>
      -Dhazelcast.mc.configReplacer.prop.passwordFile=/path/to/file \ <3>
      -Dloader.main=com.hazelcast.webmonitor.configreplacer.EncryptionReplacer \
-     org.springframework.boot.loader.PropertiesLauncher \
+     org.springframework.boot.loader.launch.PropertiesLauncher \
      "mc-test123" <4>
 ----
 


### PR DESCRIPTION
Backport of https://github.com/hazelcast/management-center-docs/pull/535

The package of the PropertiesLauncher class has been corrected. It has been updated by Spring a while ago: spring-projects/spring-boot#37667