### PR TITLE
[MC-1319] Add prometheus filters wildcard support

### DIFF
--- a/docs/modules/deploy-manage/pages/system-properties.adoc
+++ b/docs/modules/deploy-manage/pages/system-properties.adoc
@@ -843,7 +843,7 @@ hz-mc start -Dhazelcast.mc.prometheusExporter.timestamp.enabled=false \
 |[[hazelcast-mc-prometheusExporter-filter-metrics-included]]hazelcast.mc.prometheusExporter.filter.metrics.included
 
 MC_PROMETHEUS_EXPORTER_FILTER_METRICS_INCLUDED
-|Metrics to include in the `/metrics` endpoint. Default: `' '` (empty).
+|Comma-separated list of metrics to include in the `/metrics` endpoint. Supports the `*` wildcard. Default: `' '` (empty).
 |
 [source,bash,subs="attributes+"]
 ----
@@ -854,7 +854,7 @@ hz-mc start -Dhazelcast.mc.prometheusExporter.filter.metrics.included=hz_topic_t
 |[[hazelcast-mc-prometheusexporter-filter-metrics-excluded]]hazelcast.mc.prometheusExporter.filter.metrics.excluded
 
 MC_PROMETHEUS_EXPORTER_FILTER_METRICS_EXCLUDED
-|Metrics to exclude from the `/metrics` endpoint. Default: `' '` (empty).
+|Comma-separated list of metrics to exclude from the `/metrics` endpoint. Supports the `*` wildcard. Default: `' '` (empty).
 |
 [source,bash,subs="attributes+"]
 ----

--- a/docs/modules/integrate/pages/prometheus-monitoring.adoc
+++ b/docs/modules/integrate/pages/prometheus-monitoring.adoc
@@ -105,6 +105,8 @@ By default, Management Center exports all metrics that are reported by the clust
 To filter the metrics that are exposed to the scrape endpoint, use the `hazelcast.mc.prometheusExporter.filter.metrics.included`
 and `hazelcast.mc.prometheusExporter.filter.metrics.excluded` system properties.
 
+Both properties accept comma-separated metric names and support the `*` wildcard character for pattern matching.
+
 For example, this configuration exposes only the following metrics:
 
 - `hz_topic_totalReceivedMessages`
@@ -154,6 +156,30 @@ Windows::
 ----
 mc-start.cmd -Dhazelcast.mc.prometheusExporter.enabled=true ^
   -Dhazelcast.mc.prometheusExporter.filter.metrics.excluded=hz_os_systemLoadAverage,hz_memory_freeHeap
+----
+--
+====
+
+This configuration exposes only map backup metrics by using the `*` wildcard:
+
+[tabs]
+====
+Linux and Mac::
++
+--
+[source,bash,subs="attributes+"]
+----
+hz-mc start -Dhazelcast.mc.prometheusExporter.enabled=true \
+  -Dhazelcast.mc.prometheusExporter.filter.metrics.included=*map*backup*
+----
+--
+Windows::
++
+--
+[source,bash,subs="attributes+"]
+----
+mc-start.cmd -Dhazelcast.mc.prometheusExporter.enabled=true ^
+  -Dhazelcast.mc.prometheusExporter.filter.metrics.included=*map*backup*
 ----
 --
 ====


### PR DESCRIPTION
Support for the wildcards is implemented here https://github.com/hazelcast/management-center/pull/12103
Now users could use the `*` to filter metrics