### PR TITLE
Migrate Antora version update to GitHub [DI-719][DI-672]

### DIFF
--- a/.github/scripts/antora_updater.py
+++ b/.github/scripts/antora_updater.py
@@ -27,11 +27,16 @@ def process_antora(
     is_latest_stable_release: bool = False
 ) -> bool:
 
+    # Using https://yaml.dev/doc/ruamel.yaml/
     yaml: YAML = YAML()
+    # Preserve original single/double quotes
     yaml.preserve_quotes = True
+    # Preserve indentations as per current `antora.yml` layout
+    # See https://yaml.dev/doc/ruamel.yaml/detail/#Indentation_of_block_sequences
     yaml.indent(mapping=2, sequence=4, offset=2)
+    # Extend line wrapping limit to prevent premature line breaks
     yaml.width = 4096
-    
+
     with open(ANTORA_FILE, 'r+') as f:
         data = yaml.load(f)
         attrs = data['asciidoc']['attributes']

--- a/.github/scripts/antora_updater.py
+++ b/.github/scripts/antora_updater.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+import os
+import logging
+import urllib.request
+from ruamel.yaml import YAML
+
+def fetch_antora_utils() -> None:
+    branch = "DI-719-migrate-antora-1"
+    target_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "antora_utils.py")
+    url_path = f"{os.getenv('GITHUB_REPOSITORY_OWNER')}/hz-docs/{branch}/.github/scripts/antora_utils.py"
+    if not os.path.exists(target_path):
+        url = f"https://raw.githubusercontent.com/{url_path}"
+        urllib.request.urlretrieve(url, filename=target_path)
+
+fetch_antora_utils()
+import antora_utils as utils
+logger: logging.Logger = utils.setup_logger(__name__)
+
+ANTORA_FILE: str = "docs/antora.yml"
+
+def process_antora(
+    master_major_minor: str,
+    rel_major_minor: str,
+    is_main: bool,
+    is_patch_release: bool = False,
+    is_latest_stable_release: bool = False
+) -> bool:
+
+    yaml: YAML = YAML()
+    yaml.preserve_quotes = True
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.width = 4096
+    
+    with open(ANTORA_FILE, 'r+') as f:
+        data = yaml.load(f)
+        attrs = data['asciidoc']['attributes']
+        hz_page = 'page-latest-supported-hazelcast'
+
+        if is_main:
+            attrs[hz_page] = f"{master_major_minor}-snapshot"
+        else:
+            # We need to account for when MC latest version changes during latest PATCH release.
+            # The (next) v/branch needs to point to the current latest release. However,
+            # it might already be set correctly (from previous latest PATCH run) so skip
+            # update if thats the case
+            if is_patch_release and is_latest_stable_release:
+                current_value = attrs.get(hz_page, "")
+                if current_value == rel_major_minor:
+                    logger.warning(f"Skipping update - current '{hz_page}' value '{current_value}' already matches '{rel_major_minor}'")
+                    return False
+
+            attrs[hz_page] = rel_major_minor
+
+        f.seek(0)
+        yaml.dump(data, f)
+        f.truncate()
+
+    return True
+
+def update_release(
+    release_ver: str,
+    rel_major_minor: str,
+    master_major_minor: str,
+    mc_major_minor: str,
+    is_patch_release: bool = False,
+    is_latest_stable_release: bool = False
+) -> None:
+
+    target_base = f"v/{mc_major_minor}"
+    update_branch: str = utils.checkout_branch("antora", target_base)
+    
+    should_proceed = process_antora(
+        master_major_minor=master_major_minor,
+        rel_major_minor=rel_major_minor,
+        is_main=False,
+        is_patch_release=is_patch_release,
+        is_latest_stable_release=is_latest_stable_release
+    )
+    
+    if should_proceed:
+        utils.commit_changes(target_base, release_ver, [ANTORA_FILE], update_branch)
+        utils.create_github_pr(target_base, update_branch, release_ver)
+
+def update_main(
+    master_version: str,
+    master_major_minor: str
+) -> None:
+
+    target_base: str = "main"
+    update_branch: str = utils.checkout_branch("antora", target_base)
+    
+    process_antora(
+        master_major_minor=master_major_minor,
+        rel_major_minor="",
+        is_main=True
+    )
+    
+    utils.commit_changes(target_base, master_version, [ANTORA_FILE], update_branch)
+    utils.create_github_pr(target_base, update_branch, master_version)
+
+def update(
+    release_ver: str,
+    rel_major_minor: str,
+    master_version: str,
+    master_major_minor: str,
+    mc_major_minor: str,
+    is_latest_stable_release: str,
+    is_rel_major_minor: str,
+    is_patch_release: str
+) -> None:
+
+    is_patch: bool = is_patch_release == "true"
+    is_rel_maj_min: bool = is_rel_major_minor == "true"
+    is_latest_stable: bool = is_latest_stable_release == "true"
+
+    if is_rel_maj_min:
+        update_main(
+            master_version=master_version,
+            master_major_minor=master_major_minor
+        )
+
+    if is_rel_maj_min or (is_patch and is_latest_stable):
+        update_release(
+            release_ver=release_ver,
+            rel_major_minor=rel_major_minor,
+            master_major_minor=master_major_minor,
+            mc_major_minor=mc_major_minor,
+            is_patch_release=is_patch,
+            is_latest_stable_release=is_latest_stable
+        )
+    else:
+        logger.info("Skip 'antora.yml' updates for BETA or PATCH (non latest) release")
+
+def merge_pull_requests(
+    is_rel_major_minor: str,
+    is_patch_release: str,
+    is_latest_stable_release: str,
+    release_version: str,
+    master_version: str,
+    mc_major_minor: str
+) -> None:
+
+    is_patch: bool = is_patch_release == "true"
+    is_rel_maj_min: bool = is_rel_major_minor == "true"
+    is_latest_stable: bool = is_latest_stable_release == "true"
+
+    if is_rel_maj_min:
+        utils.merge_github_pr("main", master_version)
+
+    if is_rel_maj_min or (is_patch and is_latest_stable):
+        utils.merge_github_pr(
+            f"v/{mc_major_minor}",
+            release_version,
+            fail_on_missing=is_rel_maj_min
+        )
+    else:
+        logger.info("Skip 'antora.yml' updates for BETA or PATCH (non latest) release")

--- a/.github/scripts/antora_updater.py
+++ b/.github/scripts/antora_updater.py
@@ -6,7 +6,7 @@ import urllib.request
 from ruamel.yaml import YAML
 
 def fetch_antora_utils() -> None:
-    branch = "DI-719-migrate-antora-1"
+    branch = "main"
     target_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "antora_utils.py")
     url_path = f"{os.getenv('GITHUB_REPOSITORY_OWNER')}/hz-docs/{branch}/.github/scripts/antora_utils.py"
     if not os.path.exists(target_path):

--- a/.github/scripts/test_antora_updater.py
+++ b/.github/scripts/test_antora_updater.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+
+import sys
+import unittest
+import types
+import logging
+import urllib.request
+from unittest.mock import patch, call, MagicMock
+from ruamel.yaml import YAML
+
+def initialize_test_environment() -> None:
+    if "antora_utils" not in sys.modules:
+        class DynamicMockModule(types.ModuleType):
+            def __getattr__(self, name):
+                if name == "setup_logger":
+                    return lambda name: logging.getLogger(name)
+                return MagicMock()
+
+        dummy_utils = DynamicMockModule("antora_utils")
+        sys.modules["antora_utils"] = dummy_utils
+
+    global antora
+    with patch("urllib.request.urlretrieve") as mock_init_urlretrieve:
+        import antora_updater as antora
+
+initialize_test_environment()
+
+class DynamicFileSimulator:
+    def __init__(self, initial_content: str):
+        self.content = initial_content
+        self.history = []
+
+    def open_stream(self, file_path: str, mode: str):
+        return VirtualFileContext(self, mode)
+
+class VirtualFileContext:
+    def __init__(self, factory: DynamicFileSimulator, mode: str):
+        self.factory = factory
+        self.mode = mode
+        self.read_done = False
+        self.local_buffer = []
+
+    def read(self, *args, **kwargs) -> str:
+        if ("r" in self.mode or "+" in self.mode) and not self.read_done:
+            self.read_done = True
+            return self.factory.content
+        return ""
+
+    def write(self, data) -> int:
+        text_chunk = data.decode("utf-8") if isinstance(data, bytes) else data
+        self.local_buffer.append(text_chunk)
+        return len(data)
+
+    def seek(self, position: int, *args, **kwargs) -> None:
+        if position == 0:
+            self.local_buffer = []
+
+    def truncate(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if ("w" in self.mode or "+" in self.mode) and self.local_buffer:
+            completed_doc = "".join(self.local_buffer)
+            self.factory.content = completed_doc
+            self.factory.history.append(completed_doc)
+
+
+class TestAntoraUpdater(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.yaml: YAML = YAML()
+        self.yaml.preserve_quotes = True
+
+    def get_main_template(self) -> str:
+        return """name: hazelcast-management-center
+title: Hazelcast Management Center
+version: 'main'
+display_version: 'main'
+asciidoc:
+  attributes:
+    page-latest-supported-hazelcast: '5.8-snapshot'
+    experimental: true
+nav:
+  - modules/ROOT/nav.adoc
+"""
+
+    def get_release_template(self) -> str:
+        return """name: hazelcast-management-center
+title: Hazelcast Management Center
+version: '5.11'
+display_version: '5.11'
+asciidoc:
+  attributes:
+    page-latest-supported-hazelcast: '5.7'
+    experimental: true
+nav:
+  - modules/ROOT/nav.adoc
+"""
+
+    def assert_untouched_properties(self, data: dict) -> None:
+        self.assertEqual(data["name"], "hazelcast-management-center")
+        self.assertTrue(data["asciidoc"]["attributes"]["experimental"])
+
+    def test_update_is_rel_major_minor_true(self) -> None:
+        simulator = DynamicFileSimulator(self.get_main_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream) as mock_open, \
+             patch("antora_utils.checkout_branch", return_value="update_mock_branch_123") as mock_checkout, \
+             patch("antora_utils.commit_changes") as mock_commit, \
+             patch("antora_utils.create_github_pr") as mock_pr:
+
+            antora.update(
+                release_ver="5.8.0",
+                rel_major_minor="5.8",
+                master_version="5.9.0-SNAPSHOT",
+                master_major_minor="5.9",
+                mc_major_minor="5.11",
+                is_latest_stable_release="false",
+                is_rel_major_minor="true",
+                is_patch_release="false"
+            )
+
+            self.assertEqual(len(simulator.history), 2)
+            mock_checkout.assert_any_call("antora", "main")
+            mock_checkout.assert_any_call("antora", "v/5.11")
+
+            main_data = self.yaml.load(simulator.history[0])
+            release_data = self.yaml.load(simulator.history[1])
+
+            self.assertEqual(main_data["asciidoc"]["attributes"]["page-latest-supported-hazelcast"], "5.9-snapshot")
+            self.assert_untouched_properties(main_data)
+
+            self.assertEqual(release_data["asciidoc"]["attributes"]["page-latest-supported-hazelcast"], "5.8")
+            self.assert_untouched_properties(release_data)
+            mock_commit.assert_any_call("main", "5.9.0-SNAPSHOT", ["docs/antora.yml"], "update_mock_branch_123")
+            mock_commit.assert_any_call("v/5.11", "5.8.0", ["docs/antora.yml"], "update_mock_branch_123")
+            mock_pr.assert_any_call("main", "update_mock_branch_123", "5.9.0-SNAPSHOT")
+            mock_pr.assert_any_call("v/5.11", "update_mock_branch_123", "5.8.0")
+
+    def test_update_patch_and_latest_stable_with_changes(self) -> None:
+        simulator = DynamicFileSimulator(self.get_release_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream) as mock_open, \
+             patch("antora_utils.checkout_branch", return_value="update_mock_branch_123") as mock_checkout, \
+             patch("antora_utils.commit_changes") as mock_commit, \
+             patch("antora_utils.create_github_pr") as mock_pr:
+
+            antora.update(
+                release_ver="5.8.1",
+                rel_major_minor="5.8",
+                master_version="5.8.1-SNAPSHOT",
+                master_major_minor="5.8",
+                mc_major_minor="5.11",
+                is_latest_stable_release="true",
+                is_rel_major_minor="false",
+                is_patch_release="true"
+            )
+
+            self.assertEqual(len(simulator.history), 1)
+            mock_checkout.assert_called_once_with("antora", "v/5.11")
+
+            release_data = self.yaml.load(simulator.history[0])
+            self.assertEqual(release_data["asciidoc"]["attributes"]["page-latest-supported-hazelcast"], "5.8")
+            self.assert_untouched_properties(release_data)
+
+            mock_commit.assert_called_once_with("v/5.11", "5.8.1", ["docs/antora.yml"], "update_mock_branch_123")
+            mock_pr.assert_called_once_with("v/5.11", "update_mock_branch_123", "5.8.1")
+
+    def test_update_patch_and_latest_stable_already_matching_skips(self) -> None:
+        simulator = DynamicFileSimulator(self.get_release_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream) as mock_open, \
+             patch("antora_utils.checkout_branch", return_value="update_mock_branch_123") as mock_checkout, \
+             patch("antora_utils.commit_changes") as mock_commit, \
+             patch("antora_utils.create_github_pr") as mock_pr, \
+             patch("antora_updater.logger.warning") as mock_warn:
+
+            antora.update(
+                release_ver="5.7.1",
+                rel_major_minor="5.7",
+                master_version="5.7.1-SNAPSHOT",
+                master_major_minor="5.7",
+                mc_major_minor="5.11",
+                is_latest_stable_release="true",
+                is_rel_major_minor="false",
+                is_patch_release="true"
+            )
+
+            self.assertEqual(len(simulator.history), 0)
+            mock_checkout.assert_called_once_with("antora", "v/5.11")
+            mock_warn.assert_called_once_with("Skipping update - current 'page-latest-supported-hazelcast' value '5.7' already matches '5.7'")
+            mock_commit.assert_not_called()
+            mock_pr.assert_not_called()
+
+    def test_update_skip_scenario_beta(self) -> None:
+        simulator = DynamicFileSimulator(self.get_release_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream), \
+             patch("antora_utils.checkout_branch") as mock_checkout, \
+             patch("antora_updater.logger.info") as mock_logger_info:
+
+            antora.update(
+                release_ver="5.8.0-BETA1",
+                rel_major_minor="5.8",
+                master_version="5.9.0-SNAPSHOT",
+                master_major_minor="5.9",
+                mc_major_minor="5.11",
+                is_latest_stable_release="false",
+                is_rel_major_minor="false",
+                is_patch_release="false"
+            )
+
+            self.assertEqual(len(simulator.history), 0)
+            mock_checkout.assert_not_called()
+            mock_logger_info.assert_called_once_with("Skip 'antora.yml' updates for BETA or PATCH (non latest) release")
+
+    def test_update_skip_scenario_non_latest_patch(self) -> None:
+        simulator = DynamicFileSimulator(self.get_release_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream), \
+             patch("antora_utils.checkout_branch") as mock_checkout, \
+             patch("antora_updater.logger.info") as mock_logger_info:
+
+            antora.update(
+                release_ver="5.6.4",
+                rel_major_minor="5.6",
+                master_version="5.9.0-SNAPSHOT",
+                master_major_minor="5.9",
+                mc_major_minor="5.11",
+                is_latest_stable_release="false",
+                is_rel_major_minor="false",
+                is_patch_release="true"
+            )
+
+            self.assertEqual(len(simulator.history), 0)
+            mock_checkout.assert_not_called()
+            mock_logger_info.assert_called_once_with("Skip 'antora.yml' updates for BETA or PATCH (non latest) release")
+    @patch("antora_utils.merge_github_pr")
+    def test_merge_pull_requests_major_minor(self, mock_merge) -> None:
+        antora.merge_pull_requests(
+            is_rel_major_minor="true",
+            is_patch_release="false",
+            is_latest_stable_release="false",
+            release_version="5.8.0",
+            master_version="5.9.0-SNAPSHOT",
+            mc_major_minor="5.11"
+        )
+
+        mock_merge.assert_any_call("main", "5.9.0-SNAPSHOT")
+        mock_merge.assert_any_call("v/5.11", "5.8.0", fail_on_missing=True)
+
+    @patch("antora_utils.merge_github_pr")
+    def test_merge_pull_requests_patch_and_stable(self, mock_merge) -> None:
+        antora.merge_pull_requests(
+            is_rel_major_minor="false",
+            is_patch_release="true",
+            is_latest_stable_release="true",
+            release_version="5.8.1",
+            master_version="5.8.1-SNAPSHOT",
+            mc_major_minor="5.11"
+        )
+
+        mock_merge.assert_called_once_with("v/5.11", "5.8.1", fail_on_missing=False)
+
+    @patch("antora_utils.merge_github_pr")
+    def test_merge_pull_requests_skip(self, mock_merge) -> None:
+        with patch("antora_updater.logger.info") as mock_info:
+            antora.merge_pull_requests(
+                is_rel_major_minor="false",
+                is_patch_release="true",
+                is_latest_stable_release="false",
+                release_version="5.6.4",
+                master_version="5.9.0-SNAPSHOT",
+                mc_major_minor="5.11"
+            )
+            mock_merge.assert_not_called()
+            mock_info.assert_called_once_with("Skip 'antora.yml' updates for BETA or PATCH (non latest) release")
+
+    def test_update_patch_and_latest_stable_does_not_skip_on_snapshot_variants(self) -> None:
+        simulator = DynamicFileSimulator(self.get_release_template())
+        simulator.content = simulator.content.replace("'5.7'", "'5.8-SNAPSHOT'")
+
+        with patch("builtins.open", side_effect=simulator.open_stream), \
+             patch("antora_utils.checkout_branch", return_value="update_mock_branch_123") as mock_checkout, \
+             patch("antora_utils.commit_changes") as mock_commit, \
+             patch("antora_utils.create_github_pr") as mock_pr, \
+             patch("antora_updater.logger.warning") as mock_warn:
+
+            antora.update(
+                release_ver="5.8.1",
+                rel_major_minor="5.8",
+                master_version="5.8.1-SNAPSHOT",
+                master_major_minor="5.8",
+                mc_major_minor="5.11",
+                is_latest_stable_release="true",
+                is_rel_major_minor="false",
+                is_patch_release="true"
+            )
+
+            self.assertEqual(len(simulator.history), 1)
+            mock_checkout.assert_called_once_with("antora", "v/5.11")
+            mock_warn.assert_not_called()
+            mock_commit.assert_called_once()
+            mock_pr.assert_called_once()
+
+            release_data = self.yaml.load(simulator.history[0])
+            self.assertEqual(release_data["asciidoc"]["attributes"]["page-latest-supported-hazelcast"], "5.8")
+
+if __name__ == "__main__":
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,6 +2,7 @@ name: Package Release
 run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
 
 on:
+  # Called from release orchestrator
   workflow_dispatch:
     inputs:
       VERSION:
@@ -24,27 +25,20 @@ on:
         required: false
 
 jobs:
-  prepare:
-    runs-on: ubuntu-slim
-    steps:
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
   package:
-    # we need to use GH runners for now as there's a GH issue with triggering jobs on ubicloud in a private sandbox fork
-    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
-    needs: prepare
-    environment:
-      name: ${{ inputs.ENVIRONMENT }}
-      deployment: false
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
     env:
       RELEASE_VERSION: ${{ inputs.VERSION }}
     steps:
+        # https://github.com/Codex-/return-dispatch#receiving-repository-action
+      - name: Logging distinct ID (${{ inputs.distinct_id }})
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
+
       - name: Checkout `release` branch
         uses: actions/checkout@v7
         with:
@@ -57,12 +51,10 @@ jobs:
 
       - name: Get release info
         id: get-rel-info
-        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        uses: hazelcast/mono-actions/get-release-info@DI-719-migrate-antora-1
         with:
           release-version: ${{ env.RELEASE_VERSION }}
-          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
           github-token: ${{ secrets.GH_TOKEN }}
-          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
 
       - name: Install ruamel.yaml
         run: python3 -m pip install ruamel.yaml packaging
@@ -91,7 +83,6 @@ jobs:
               is_patch_release=getenv("IS_PATCH_RELEASE")
           )
         env:
-          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
           REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.rel-major-minor }}
           MASTER_VERSION: ${{ steps.get-rel-info.outputs.master-version }}
           MASTER_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.master-major-minor }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,103 @@
+name: Package Release
+run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: 'The version to build (e.g. `5.4.1`)'
+        required: true
+      RELEASE_TYPE:
+        description: 'What should be built'
+        required: true
+        type: choice
+        options:
+          - ALL
+          - OSS
+          - EE
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: environment
+      distinct_id:
+        description: 'Required exclusively for automated execution to track status of workflow execution'
+        required: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Logging distinct ID (${{ inputs.distinct_id }})
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
+
+  package:
+    # we need to use GH runners for now as there's a GH issue with triggering jobs on ubicloud in a private sandbox fork
+    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
+    needs: prepare
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
+    permissions:
+      id-token: write
+      contents: write
+    env:
+      RELEASE_VERSION: ${{ inputs.VERSION }}
+    steps:
+      - name: Checkout `release` branch
+        uses: actions/checkout@v7
+        with:
+          path: ${{ env.RELEASE_VERSION }}
+
+      - name: Checkout `main` automation scripts
+        uses: actions/checkout@v7
+        with:
+          path: src-scripts
+
+      - name: Get release info
+        id: get-rel-info
+        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        with:
+          release-version: ${{ env.RELEASE_VERSION }}
+          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
+          github-token: ${{ secrets.GH_TOKEN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+
+      - name: Install ruamel.yaml
+        run: python3 -m pip install ruamel.yaml packaging
+
+      - name: Configure git
+        working-directory: ${{ env.RELEASE_VERSION }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Update antora.yml with Pull Requests
+        shell: python
+        working-directory: ${{ env.RELEASE_VERSION }}
+        run: |
+          from os import getenv
+          import antora_updater as antora
+
+          antora.update(
+              release_ver=getenv("RELEASE_VERSION"),
+              rel_major_minor=getenv("REL_MAJOR_MINOR"),
+              master_version=getenv("MASTER_VERSION"),
+              master_major_minor=getenv("MASTER_MAJOR_MINOR"),
+              mc_major_minor=getenv("MC_MAJOR_MINOR"),
+              is_latest_stable_release=getenv("IS_LATEST_STABLE_RELEASE"),
+              is_rel_major_minor=getenv("IS_REL_MAJOR_MINOR"),
+              is_patch_release=getenv("IS_PATCH_RELEASE")
+          )
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.rel-major-minor }}
+          MASTER_VERSION: ${{ steps.get-rel-info.outputs.master-version }}
+          MASTER_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.master-major-minor }}
+          MC_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.mc-major-minor }}
+          IS_LATEST_STABLE_RELEASE: ${{ steps.get-rel-info.outputs.is-latest-stable-release }}
+          IS_REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.is-rel-major-minor }}
+          IS_PATCH_RELEASE: ${{ steps.get-rel-info.outputs.is-patch-release }}
+          PYTHONPATH: ${{ github.workspace }}/src-scripts/.github/scripts
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get release info
         id: get-rel-info
-        uses: hazelcast/mono-actions/get-release-info@DI-719-migrate-antora-1
+        uses: hazelcast/mono-actions/get-release-info@main
         with:
           release-version: ${{ env.RELEASE_VERSION }}
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,39 +25,28 @@ on:
         required: false
 
 jobs:
-  prepare:
-    # we need to use GH runners for now as there's a GH issue with triggering jobs on ubicloud in a private sandbox fork ff
-    runs-on: ubuntu-slim
-    steps:
-        # https://github.com
-      - name: Logging distinct ID (${{ inputs.distinct_id }})
-        run: echo "${DISTINCT_ID}"
-        env:
-          DISTINCT_ID: ${{ inputs.distinct_id }}
-
   promote:
-    # we need to use GH runners for now as there's a GH issue with triggering jobs on ubicloud in a private sandbox fork
-    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
-    needs: prepare
-    environment:
-      name: ${{ inputs.ENVIRONMENT }}
-      deployment: false
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       id-token: write
       pull-requests: write
     steps:
+        # https://github.com/Codex-/return-dispatch#receiving-repository-action
+      - name: Logging distinct ID (${{ inputs.distinct_id }})
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
+
       - name: Checkout `main` automation scripts
         uses: actions/checkout@v7
 
       - name: Get release info
         id: get-rel-info
-        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        uses: hazelcast/mono-actions/get-release-info@DI-719-migrate-antora-1
         with:
           release-version: ${{ inputs.VERSION }}
-          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
           github-token: ${{ secrets.GH_TOKEN }}
-          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
 
       - name: Install ruamel.yaml
         run: python3 -m pip install ruamel.yaml packaging

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Get release info
         id: get-rel-info
-        uses: hazelcast/mono-actions/get-release-info@DI-719-migrate-antora-1
+        uses: hazelcast/mono-actions/get-release-info@main
         with:
           release-version: ${{ inputs.VERSION }}
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,87 @@
+name: Promote Release
+run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
+
+on:
+  # Called from release orchestrator
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: 'The version to promote (e.g. `5.4.1`)'
+        required: true
+      RELEASE_TYPE:
+        description: 'What should be promoted'
+        required: true
+        type: choice
+        options:
+          - ALL
+          - OSS
+          - EE
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: environment
+      distinct_id:
+        description: 'Required exclusively for automated execution to track status of workflow execution'
+        required: false
+
+jobs:
+  prepare:
+    # we need to use GH runners for now as there's a GH issue with triggering jobs on ubicloud in a private sandbox fork ff
+    runs-on: ubuntu-slim
+    steps:
+        # https://github.com
+      - name: Logging distinct ID (${{ inputs.distinct_id }})
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
+
+  promote:
+    # we need to use GH runners for now as there's a GH issue with triggering jobs on ubicloud in a private sandbox fork
+    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
+    needs: prepare
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout `main` automation scripts
+        uses: actions/checkout@v7
+
+      - name: Get release info
+        id: get-rel-info
+        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        with:
+          release-version: ${{ inputs.VERSION }}
+          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
+          github-token: ${{ secrets.GH_TOKEN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+
+      - name: Install ruamel.yaml
+        run: python3 -m pip install ruamel.yaml packaging
+
+      - name: Merge Antora Pull Requests
+        shell: python
+        run: |
+          from os import getenv
+          import antora_updater as updater
+
+          updater.merge_pull_requests(
+              is_rel_major_minor=getenv("IS_REL_MAJOR_MINOR"),
+              is_patch_release=getenv("IS_PATCH_RELEASE"),
+              is_latest_stable_release=getenv("IS_LATEST_STABLE_RELEASE"),
+              release_version=getenv("RELEASE_VERSION"),
+              master_version=getenv("MASTER_VERSION"),
+              mc_major_minor=getenv("MC_MAJOR_MINOR")
+          )
+        env:
+          RELEASE_VERSION: ${{ inputs.VERSION }}
+          MASTER_VERSION: ${{ steps.get-rel-info.outputs.master-version }}
+          MC_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.mc-major-minor }}
+          IS_REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.is-rel-major-minor }}
+          IS_PATCH_RELEASE: ${{ steps.get-rel-info.outputs.is-patch-release }}
+          IS_LATEST_STABLE_RELEASE: ${{ steps.get-rel-info.outputs.is-latest-stable-release }}
+          PYTHONPATH: ${{ github.workspace }}/.github/scripts
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -1,0 +1,34 @@
+name: Run release unit tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/package-release.yml'
+      - '.github/workflows/promote-release.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    # Ignore automated release PR branches
+    if: ${{ !startsWith(github.head_ref, 'update_antora_') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruamel.yaml
+        run: python3 -m pip install ruamel.yaml packaging
+
+      - name: Run unit tests
+        run: |
+          python3 -m unittest discover -s .github/scripts -p "test_*.py"

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -19,9 +19,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Install ruamel.yaml
-        run: python3 -m pip install ruamel.yaml packaging
+      - name: Install Python packages
+        run: python3 -m pip install ruamel.yaml pytest
 
       - name: Run unit tests
         run: |
-          python3 -m unittest discover -s .github/scripts -p "test_*.py"
+          pytest .github/scripts/ --junit-xml=test-results/results.xml
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
+        if: always()
+        with:
+          files: test-results/results.xml

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -4,12 +4,10 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize]
     paths:
-      - '.github/scripts/**'
-      - '.github/workflows/package-release.yml'
-      - '.github/workflows/promote-release.yml'
-  workflow_dispatch:
+      - '.github/scripts/*.py'
+      - '.github/workflows/package.yml'
+      - '.github/workflows/promote.yml'
 
 jobs:
   test:
@@ -20,11 +18,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install ruamel.yaml
         run: python3 -m pip install ruamel.yaml packaging

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   validate-docs:
-
+    # Ignore automated release PR branches
+    if: ${{ !startsWith(github.head_ref, 'update_antora_') }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Current Repo
         uses: actions/checkout@v7

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@
 /build/
 global-antora-playbook.yml
 _redirects
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.env
+.pytest_cache/
+.unittest_cache/


### PR DESCRIPTION
### Details
Adds scripts and workflows to update Hazelcast `antora.yml` version updates:

| Type | Info|
| :--- | :--- |
| **MAJOR/MINOR** | Updates `main` branch version to the current `hazelcast-mono@master` POM version and updates `v/branch` branch to the current release. |
| **PATCH** | Updates `v/branch` branch version with the current release version only when PATCH is `latest`|
| **BETA** | Skipped |

### Testing

Tested in `sandbox`

1.  `ReleaseInfo` generated via https://github.com/hazelcast/mono-actions/pull/26
2. Workflows (`package` and `promote`) triggered manually

| Version  | Resulting PR|
| :--- | :--- | 
| <summary><b>MAJOR/MINOR (5.8.0)</b></summary> | |
| main | [Pull Request #15](https://github.com/hz-devops-test/management-center-docs/pull/15) |
| v/5.11| [Pull Request #16](https://github.com/hz-devops-test/management-center-docs/pull/16) |
| <summary><b>PATCH 5.8.2 (`latest`)</b></summary> | |
|  v/5.12 | [Pull Request #17](https://github.com/hz-devops-test/management-center-docs/pull/17) |
| <summary><b>BETA/PATCH (all skipped as per below runs)</b></summary> | | 
| v/5.9-BETA-1 (5.9.0-BETA-1) | [Package ](https://github.com/hz-devops-test/management-center-docs/actions/runs/29157484151), [Promote ](https://github.com/hz-devops-test/management-center-docs/actions/runs/29157545114)|
| v/5.8 (5.8.1) | [Package ](https://github.com/hz-devops-test/management-center-docs/actions/runs/29156717324), [Promote ](https://github.com/hz-devops-test/management-center-docs/actions/runs/29156765965)| 
| v/5.7 (5.7.6) | [Package ](https://github.com/hz-devops-test/management-center-docs/actions/runs/29157597954), [Promote ](https://github.com/hz-devops-test/management-center-docs/actions/runs/29157638359)|

Version `5.8.2` is a special case which used fake MC `v/5.12` (see [ReleaseInfo-5.8.2.json)](https://hazelcast.jfrog.io/artifactory/sandbox-files-preprod/hazelcast-enterprise/ReleaseInfo-5.8.2.json)). The MC version can change during PATCH `latest` release and this was never accounted for in Release Pipeline. Now we ensure the MC `v/branch` is always pointing to the latest HZ release

### Additional fix

This also fixes [DI-672](https://hazelcast.atlassian.net/browse/DI-672) - the Release Pipeline updated the wrong `v/branch`. Instead of updating MC version `v/branch`, it blindly used the HZ release version to compute the `v/branch`. This was ok when HZ release matched MC version but not when MC was newer release (which can happen even during a PATCH release which also accounted for)

### Pre merge

- [ ] Replace all occurrences of `DI-719-migrate-antora-1` to `main`


Fixes: [DI-719](https://hazelcast.atlassian.net/browse/DI-719), [DI-672](https://hazelcast.atlassian.net/browse/DI-672)

[DI-719]: https://hazelcast.atlassian.net/browse/DI-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DI-672]: https://hazelcast.atlassian.net/browse/DI-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ