### PR TITLE
Move to Hazelcast 6.0 development cycle

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,7 +15,7 @@ asciidoc:
     snapshot: true
     javasource: ROOT:example$
     mc-repo-swagger-branch: 'master'
-    page-latest-supported-hazelcast: '5.8-snapshot'
+    page-latest-supported-hazelcast: '6.0-snapshot'
     # https://github.com/hazelcast/hazelcast-commandline-client/releases
     page-latest-supported-clc: '5.5.1'
     page-toclevels: 1


### PR DESCRIPTION
At the back of https://github.com/hazelcast/hazelcast-mono/pull/7393
Normally, the Release Pipeline does this update during release
But `6.0.0` release is planned for later; hence, manual update!